### PR TITLE
don't throw a MatchError on `SCALA_210 compare SCALA_28_29`

### DIFF
--- a/scalariform/src/main/scala/scalariform/ScalaVersions.scala
+++ b/scalariform/src/main/scala/scalariform/ScalaVersions.scala
@@ -5,20 +5,13 @@ import scala.util.Properties
 /**
  * A group of Scala versions that Scalariform wants to distinguish because they have incompatible syntax
  */
-sealed trait ScalaVersionGroup extends Ordered[ScalaVersionGroup] {
-
-  def compare(that: ScalaVersionGroup) =
-    this match {
-      case `that`      ⇒ 0
-      case SCALA_28_29 ⇒ -1
-      case SCALA_211   ⇒ 1
-    }
-
+sealed class ScalaVersionGroup(protected[scalariform] val internalVersion: Int) extends Ordered[ScalaVersionGroup] {
+  def compare(that: ScalaVersionGroup) = internalVersion compare that.internalVersion
 }
 
-case object SCALA_28_29 extends ScalaVersionGroup
-case object SCALA_210 extends ScalaVersionGroup
-case object SCALA_211 extends ScalaVersionGroup
+case object SCALA_28_29 extends ScalaVersionGroup(0)
+case object SCALA_210 extends ScalaVersionGroup(1)
+case object SCALA_211 extends ScalaVersionGroup(2)
 
 object ScalaVersions {
 


### PR DESCRIPTION
I encountered this when using today's Eclipse build (scalariform 0.1.2.201204270551):
Problems occurred when invoking code from plug-in: "org.eclipse.search".
scala.MatchError: SCALA_210 (of class scalariform.SCALA_210$)
    at scalariform.ScalaVersionGroup$class.compare(ScalaVersions.scala:11)
    at scalariform.SCALA_210$.compare(ScalaVersions.scala:20)
    at scalariform.SCALA_210$.compare(ScalaVersions.scala:20)
    at scala.math.Ordered$class.$greater$eq(Ordered.scala:86)
    at scalariform.SCALA_210$.$greater$eq(ScalaVersions.scala:20)
    at scalariform.lexer.ScalaOnlyLexer$class.getNumber(ScalaOnlyLexer.scala:468)
