### PR TITLE
Replaced references to scala-tools.org by Sonatype.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,28 +69,20 @@
       <url>http://download.eclipse.org/releases/galileo</url>
     </repository>
     <repository>
-      <id>scala-tools.org.releases</id>
-      <name>Scala Tools Maven2 Repository</name>
-      <url>http://scala-tools.org/repo-releases</url>
+      <id>sonatype.release</id>
+      <name>Sonatype maven release repository</name>
+      <url>https://oss.sonatype.org/content/repositories/releases/</url>
+      <snapshots><enabled>false</enabled></snapshots>
     </repository>
     <repository>
-      <id>scala-tools.snapshot</id>
-      <name>Scala Tools maven snapshot repository</name>
-      <url>http://scala-tools.org/repo-snapshots</url>
+      <id>sonatype.snapshot</id>
+      <name>Sonatype maven snapshot repository</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <updatePolicy>daily</updatePolicy>
+      </snapshots>
     </repository>
   </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>scala-tools.release</id>
-      <name>Scala Tools maven release repository</name>
-      <url>http://scala-tools.org/repo-releases</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>scala-tools.snapshot</id>
-      <name>Scala Tools maven snapshot repository</name>
-      <url>http://scala-tools.org/repo-snapshots</url>
-    </pluginRepository>
-  </pluginRepositories>
   <profiles>
     <profile>
       <id>scala-2.9.x</id>


### PR DESCRIPTION
Also removed `<pluginRepository>` entries, as they seemed unused.
