### PR TITLE
Fix for issue #62.

### DIFF
--- a/scalariform/src/main/scala/scalariform/formatter/CommentFormatter.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/CommentFormatter.scala
@@ -14,7 +14,8 @@ trait CommentFormatter { self: HasFormattingPreferences with ScalaFormatter ⇒
     val (contents, _) = rest.splitAt(rest.length - "*/".length)
     val firstLine :: otherLines = contents.split("""\r?\n([ \t]*(\*(?!/))?)?""", Integer.MAX_VALUE).toList
     val afterStarSpaces = if (formattingPreferences(MultilineScaladocCommentsStartOnFirstLine)) 2 else 1
-    val adjustedLines = dropInitialSpaces(firstLine, 1) :: (otherLines map { dropInitialSpaces(_, afterStarSpaces) })
+    val initialSpaces = firstLine takeWhile (_.isWhitespace)
+    val adjustedLines = dropInitialSpaces(firstLine, initialSpaces.size) :: (otherLines map { dropInitialSpaces(_, afterStarSpaces) })
     //    val adjustedLines map { line ⇒ if (line startsWith "*/") "*" + line else line }
     (start, adjustedLines)
   }

--- a/scalariform/src/test/scala/scalariform/formatter/CommentFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/CommentFormatterTest.scala
@@ -10,12 +10,12 @@ class CommentFormatterTest extends AbstractFormatterTest {
   type Result = CompilationUnit
 
   def parse(parser: ScalaParser) = parser.scriptBody()
-  
+
   def format(formatter: ScalaFormatter, result: Result) = formatter.format(result)(FormatterState())
 
   override val debug = false
 
-  """/** 
+  """/**
     |*a
     |b
     | */c""" ==>
@@ -25,7 +25,7 @@ class CommentFormatterTest extends AbstractFormatterTest {
     | */
     |c"""
 
-  """/** 
+  """/**
     |*a
     |b
     | */""" ==>
@@ -37,7 +37,7 @@ class CommentFormatterTest extends AbstractFormatterTest {
 
   """/**
     | *
-    | *Wibble*/ 
+    | *Wibble*/
     |class X""" ==>
   """/**
     | *
@@ -88,7 +88,7 @@ class CommentFormatterTest extends AbstractFormatterTest {
     | * b
     | */
     |"""
-      
+
   // nested comments
   """/**
     |/*
@@ -99,17 +99,17 @@ class CommentFormatterTest extends AbstractFormatterTest {
     | * */
     | */
     |"""
-      
+
   {
   implicit val formattingPreferences = FormattingPreferences.setPreference(MultilineScaladocCommentsStartOnFirstLine, true)
 
-  """/** This method applies f to each 
+  """/** This method applies f to each
     | *  element of the given list.
     | */""" ==>
   """/** This method applies f to each
     | *  element of the given list.
     | */
-    |""" 
+    |"""
 
   """/** Foo
     |Bar
@@ -132,18 +132,18 @@ class CommentFormatterTest extends AbstractFormatterTest {
     | */
     |"""
   }
-  
+
   {
   implicit val formattingPreferences = FormattingPreferences.setPreference(PlaceScaladocAsterisksBeneathSecondAsterisk, true)
 
-  """/** This method applies f to each 
+  """/** This method applies f to each
     | * element of the given list.
     | */""" ==>
   """/**
     |  * This method applies f to each
     |  * element of the given list.
     |  */
-    |""" 
+    |"""
 
   """/** Foo
     |Bar
@@ -168,18 +168,18 @@ class CommentFormatterTest extends AbstractFormatterTest {
     |  */
     |"""
   }
-  
+
   {
   implicit val formattingPreferences = FormattingPreferences
     .setPreference(MultilineScaladocCommentsStartOnFirstLine, true)
     .setPreference(PlaceScaladocAsterisksBeneathSecondAsterisk, true)
-  """/** This method applies f to each 
+  """/** This method applies f to each
     | * element of the given list.
     | */""" ==>
   """/** This method applies f to each
     |  * element of the given list.
     |  */
-    |""" 
+    |"""
 
   """/** Foo
     |Bar
@@ -199,6 +199,14 @@ class CommentFormatterTest extends AbstractFormatterTest {
   """/**
     |*/""" ==>
   """/**
+    |  */
+    |"""
+
+  """/**          This method applies f to each
+    | * element of the given list.
+    | */""" ==>
+  """/** This method applies f to each
+    |  * element of the given list.
     |  */
     |"""
   }


### PR DESCRIPTION
Don't drop a maximum of one space when trimming the
leading whitespace of an initial scaladoc line.
