### PR TITLE
Upgrade to scala-maven-plugin 3.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,14 @@
     <scala.version>2.8.0</scala.version>
     <repo.scala-ide>http://download.scala-ide.org</repo.scala-ide>
     <encoding>UTF-8</encoding>
+    <maven.version>3.0.4</maven.version>
   </properties>
+
+  <prerequisites>
+    <maven>${maven.version}</maven>
+  </prerequisites>
+
+
   <modules>
     <module>scalariform</module>
     <module>scalariform.feature</module>
@@ -83,9 +90,9 @@
         </configuration>
       </plugin>    
       <plugin>
-        <groupId>org.scala-tools</groupId>
-        <artifactId>maven-scala-plugin</artifactId>
-        <version>2.14</version>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.1.5</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
This newer version of the scala plugin for maven doesn't crash on a modularized scala (https://github.com/scala/scala/pull/2855). 

Full disclosure: I wouldn't go as far as saying that 3.1.5 fully supports a modularized Scala -- a fix is in the works for 3.1.6

/cc @dotta
