### PR TITLE
add support for sbt script

### DIFF
--- a/scalariform/src/main/scala/scalariform/formatter/ScalaFormatter.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/ScalaFormatter.scala
@@ -178,9 +178,13 @@ abstract class ScalaFormatter extends HasFormattingPreferences with TypeFormatte
           for ((previousOpt, hiddenToken, nextOpt) ← Utils.withPreviousAndNext(hiddenTokens)) {
             hiddenToken match {
               case ScalaDocComment(token) ⇒
-                builder.ensureAtBeginningOfLine()
-                builder.indent(commentIndentLevel, baseIndentOption)
-                builder.append(formatComment(hiddenToken, commentIndentLevel))
+                if (token.rawText.startsWith("/***")){
+                  builder.append(token.rawText)
+                } else {
+                  builder.ensureAtBeginningOfLine()
+                  builder.indent(commentIndentLevel, baseIndentOption)
+                  builder.append(formatComment(hiddenToken, commentIndentLevel))
+                }
               case SingleLineComment(_) | MultiLineComment(_) ⇒
                 if (builder.atBeginningOfLine)
                   builder.indent(commentIndentLevel, baseIndentOption)

--- a/scalariform/src/test/scala/scalariform/formatter/CommentFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/CommentFormatterTest.scala
@@ -203,4 +203,26 @@ class CommentFormatterTest extends AbstractFormatterTest {
     |"""
   }
 
+  {
+    """object Main {
+      |/***
+      |scalaVersion := "ololo"
+      |
+      |libraryDependencies ++= Seq(
+      |  "net.databinder" % "dispatch-twitter_2.9.0-1" % "0.8.3",
+      |  "net.databinder" % "dispatch-http_2.9.0-1" % "0.8.3"
+      |)
+      |*/
+      |}""" ==>
+      """object Main {
+        |/***
+        |scalaVersion := "ololo"
+        |
+        |libraryDependencies ++= Seq(
+        |  "net.databinder" % "dispatch-twitter_2.9.0-1" % "0.8.3",
+        |  "net.databinder" % "dispatch-http_2.9.0-1" % "0.8.3"
+        |)
+        |*/
+        |}"""
+  }
 }


### PR DESCRIPTION
(cherry picked from commit d2d1929)
This ensures that a comment with meta information for sbt script http://www.scala-sbt.org/release/docs/Detailed-Topics/Scripts#sbt-script-runner is not formatted.