### PR TITLE
Updated dead Compact Control Readability wikipedia link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -188,9 +188,9 @@ Default: ``false``
 
 When ``compactControlReadability`` is ``true``, ``if``/``else`` and
 ``try``/``catch``/``finally`` control structures will be formatted
-using `Compact Control Readability`_ style:
+using `Stroustrup K&R`_ style:
 
-.. _Compact Control Readability: http://en.wikipedia.org/wiki/Indent_style#Compact_Control_Readability_style
+.. _Stroustrup K&R: http://en.wikipedia.org/wiki/Indent_style#Variant:_Stroustrup
 
   if (x == y) {
     foo()


### PR DESCRIPTION
http://en.wikipedia.org/w/index.php?title=Indent_style&diff=578889505&oldid=578558019 is the version that removed the previous section