### PR TITLE
Scala 2.11

### DIFF
--- a/cli/src/main/scala/scalariform/commandline/Main.scala
+++ b/cli/src/main/scala/scalariform/commandline/Main.scala
@@ -13,7 +13,7 @@ import scalariform.ScalaVersions
 object Main {
 
   def main(args: Array[String]) {
-    exit(if (process(args)) 1 else 0)
+    java.lang.System.exit(if (process(args)) 1 else 0)
   }
 
   def process(args: Array[String]): Boolean = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,9 +12,9 @@ object ScalariformBuild extends Build {
   lazy val commonSettings = Defaults.defaultSettings ++ SbtScalariform.defaultScalariformSettings ++ Seq(
     organization := "org.scalariform",
     version := "0.1.5-SNAPSHOT",
-    scalaVersion := "2.10.0",
+    scalaVersion := "2.11.0",
     crossScalaVersions := Seq(
-      //      "2.11.0-M2",
+      "2.11.0",
       "2.10.0", "2.10.1",
       "2.9.3", "2.9.2", "2.9.1-1", "2.9.1", "2.9.0-1", "2.9.0",
       "2.8.2", "2.8.1", "2.8.0"),
@@ -34,18 +34,19 @@ object ScalariformBuild extends Build {
     publish := (),
     publishLocal := ())) aggregate (scalariform, cli, misc)
 
-  def getScalaTestDependency(scalaVersion: String) = scalaVersion match {
-    case "2.8.0"  ⇒ "org.scalatest" %% "scalatest" % "1.3.1.RC2" % "test"
-    case "2.10.0" ⇒ "org.scalatest" %% "scalatest" % "1.9.1" % "test"
-    case "2.10.1" ⇒ "org.scalatest" %% "scalatest" % "1.9.1" % "test"
-    case "2.9.3"  ⇒ "org.scalatest" %% "scalatest" % "1.9.1" % "test"
-    case _        ⇒ "org.scalatest" %% "scalatest" % "1.7.2" % "test"
+  def getScalaVersionDependencies(scalaVersion: String) = scalaVersion match {
+    case "2.8.0"  ⇒ Seq("org.scalatest" %% "scalatest" % "1.3.1.RC2" % "test")
+    case "2.10.0" ⇒ Seq("org.scalatest" %% "scalatest" % "1.9.1" % "test")
+    case "2.10.1" ⇒ Seq("org.scalatest" %% "scalatest" % "1.9.1" % "test")
+    case "2.9.3"  ⇒ Seq("org.scalatest" %% "scalatest" % "1.9.1" % "test")
+    case "2.11.0" ⇒ Seq("org.scalatest" %% "scalatest" % "2.1.4" % "test", "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1", "org.scala-lang.modules" %% "scala-xml" % "1.0.1")
+    case _        ⇒ Seq("org.scalatest" %% "scalatest" % "1.7.2" % "test")
   }
 
   lazy val scalariform: Project = Project("scalariform", file("scalariform"), settings =
     subprojectSettings ++ sbtbuildinfo.Plugin.buildInfoSettings ++ eclipseSettings ++
       Seq(
-        libraryDependencies <<= (scalaVersion, libraryDependencies) { (sv, deps) ⇒ deps :+ getScalaTestDependency(sv) },
+        libraryDependencies <<= (scalaVersion, libraryDependencies) { (sv, deps) ⇒ deps ++ getScalaVersionDependencies(sv) },
         pomExtra := pomExtraXml,
         publishMavenStyle := true,
         publishArtifact in Test := false,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.3
+sbt.version=0.13.2


### PR DESCRIPTION
Updates the build to Scala 2.11. Not all of the cross builds work but this 2.11 version fails in the same was as the 2.10 version so it isn't a regression.  :-)