### PR TITLE
Fix return value of commandline.Main.checkFile

### DIFF
--- a/cli/src/main/scala/scalariform/commandline/Main.scala
+++ b/cli/src/main/scala/scalariform/commandline/Main.scala
@@ -272,7 +272,7 @@ object Main {
     }
     val padding = " " * (6 - resultString.length)
     log("[" + resultString + "]" + padding + " " + file)
-    formatResult != FormattedCorrectly
+    formatResult == FormattedCorrectly
   }
 
   /**


### PR DESCRIPTION
It was reversed, which meant we were getting the wrong exit code when
running the CLI with `--test`.