### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ the way you'd like it, and I'll see what I can do.
 Scalariform is licenced under `The MIT Licence`_.
 
 .. _Scala Style Guide: http://docs.scala-lang.org/style/
-.. _The MIT Licence: http://www.opensource.org/licenses/mit-license.php
+.. _The MIT Licence: http://opensource.org/licenses/mit-license.php
 
 Installing with Homebrew (for OS X users)
 -----------------------------------------
@@ -81,16 +81,16 @@ Integration with Emacs/ENSIME
 
 "`ENSIME`_ uses the Scalariform library to format Scala sources. Type C-c C-v f to format the current buffer."
 
-  http://aemon.com/file_dump/ensime_manual.html#tth_sEc4.8
+  http://www.aemon.com/file_dump/ensime_manual.html#tth_sEc4.8
 
-.. _ENSIME: http://github.com/aemoncannon/ensime
+.. _ENSIME: https://github.com/ensime/ensime-server
 
 Integration with jEdit
 ----------------------
 
 See `ScalaSidekick`_ by Stefan Ettrup:
 
-.. _ScalaSidekick: http://github.com/StefanE/ScalaSidekick
+.. _ScalaSidekick: https://github.com/StefanE/ScalaSidekick
 
 Run Plugins -> scalaSidekickPlugin -> Format Scala File
 
@@ -126,7 +126,7 @@ Integration with TextMate
 
 See Mads Jensen's Scala TextMate bundle:
 
-  http://github.com/mads379/scala.tmbundle
+  https://github.com/mads379/scala.tmbundle
 
 Reformat using Ctrl-Shift-H.
 
@@ -281,7 +281,7 @@ When ``compactControlReadability`` is ``true``, then ``if``/``else`` and
 ``try``/``catch``/``finally`` control structures will be formatted
 using `Compact Control Readability`_ style
 
-.. _Compact Control Readability: http://en.wikipedia.org/wiki/Indent_style#Variant:_Stroustrup
+.. _Compact Control Readability: https://en.wikipedia.org/wiki/Indent_style#Variant:_Stroustrup
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Usage within a project
 
 Have a use for the scalariform source code directly? You can use it as a build dependency: ::
 
-    "org.scalariform" %% "scalariform" % "0.1.7"
+    "org.scalariform" %% "scalariform" % "0.2.0"
 
 Integration with Eclipse
 ------------------------
@@ -148,12 +148,12 @@ You can create your own executable scalariform.jar by following the instructions
 Command line tool
 -----------------
 
-  https://github.com/mdr/scalariform/wiki/Command-line-tool
+  https://github.com/scala-ide/scalariform/wiki/Command-line-tool
 
 Library
 -------
 
-  https://github.com/mdr/scalariform/wiki/Library
+  https://github.com/scala-ide/scalariform/wiki/Library
 
 Preferences
 -----------
@@ -477,6 +477,36 @@ If ``true``, the formatter will keep an existing space before a parenthesis argu
   stack.pop() should equal (2)
 
 Otherwise, if ``false``, spaces before arguments will always be removed.
+
+danglingCloseParenthesis
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``Force``
+
+If ``Force``, any closing parentheses will be set to dangle. For example::
+
+   Box(
+     contents: List[Thing])
+
+becomes::
+
+   Box(
+     contents: List[Thing]
+   )
+
+If ``Prevent``, all dangling parenthesis are collapsed. For example::
+
+   Box(
+     contents: List[Thing]
+   )
+
+becomes::
+
+   Box(
+     contents: List[Thing])
+
+If ``Preserve``, scalariform will try to match what unformatted source code is already doing per parenthesis,
+either forcing or preventing.
 
 rewriteArrowSymbols
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
http://github.com/aemoncannon/ensime | https://github.com/ensime/ensime-server 
https://github.com/mdr/scalariform/wiki/Command-line-tool | https://github.com/scala-ide/scalariform/wiki/Command-line-tool 
https://github.com/mdr/scalariform/wiki/Library | https://github.com/scala-ide/scalariform/wiki/Library 


### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://en.wikipedia.org/wiki/Indent_style#Variant:_Stroustrup | https://en.wikipedia.org/wiki/Indent_style#Variant:_Stroustrup 
http://github.com/StefanE/ScalaSidekick | https://github.com/StefanE/ScalaSidekick 
http://github.com/mads379/scala.tmbundle | https://github.com/mads379/scala.tmbundle 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://aemon.com/file_dump/ensime_manual.html#tth_sEc4.8 | http://www.aemon.com/file_dump/ensime_manual.html#tth_sEc4.8 
http://www.opensource.org/licenses/mit-license.php | http://opensource.org/licenses/mit-license.php 
