### PR TITLE
Add lexer support for string extractors with wildcards

### DIFF
--- a/scalariform/src/main/scala/scalariform/lexer/ScalaOnlyLexer.scala
+++ b/scalariform/src/main/scala/scalariform/lexer/ScalaOnlyLexer.scala
@@ -238,6 +238,9 @@ private[lexer] trait ScalaOnlyLexer { self: ScalaLexer ⇒
       if (ch == '$') {
         nextChar()
         getStringPart(multiLine)
+      } else if (ch == '_') {
+        token(STRING_PART)
+        stringInterpolationMode.interpolationVariable = true
       } else if (ch == '{') {
         token(STRING_PART)
         switchToScalaMode()

--- a/scalariform/src/test/scala/scalariform/lexer/ScalaLexerTest.scala
+++ b/scalariform/src/test/scala/scalariform/lexer/ScalaLexerTest.scala
@@ -129,6 +129,8 @@ class ScalaLexerTest extends FlatSpec with ShouldMatchers {
 
     """ s"$this" """ producesTokens (WS, INTERPOLATION_ID, STRING_PART, THIS, STRING_LITERAL, WS)
 
+    """ s"$_" """ producesTokens (WS, INTERPOLATION_ID, STRING_PART, USCORE, STRING_LITERAL, WS)
+
     <t>s""""""</t>.text producesTokens (INTERPOLATION_ID, STRING_LITERAL)
     <t>s"""""""""</t>.text producesTokens (INTERPOLATION_ID, STRING_LITERAL)
     <t>s""" $foo """</t>.text producesTokens (INTERPOLATION_ID, STRING_PART, VARID, STRING_LITERAL)


### PR DESCRIPTION
Extractors against interpolated strings containing wildcards are currently unsupported and cause a `ScalaLexerException` with message "invalid string interpolation".

Snippet that triggers an exception:

    def unwrapAnonInstance(tree: Tree) = tree match {
      case Block(
        q"""$_ class $name1 extends ..$_ { ..$stats }""" :: Nil,
        q"new ${ Ident(name2) }"
        ) if name1 == name2 ⇒
        Some(stats)
      case _ ⇒
        None
    }

This PR fixes this. *(Note: I wasn't positive what token should be emitted, so I left it at `USCORE`)*