### PR TITLE
Fix whitespace.

### DIFF
--- a/scalariform/src/test/scala/scalariform/formatter/CommentFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/CommentFormatterTest.scala
@@ -180,6 +180,17 @@ class CommentFormatterTest extends AbstractFormatterTest {
     |  */
     |"""
 
+  """/**
+    | * Scaladoc should be retained.
+    | * @param first line retains indent.
+    | *     second line retains indent.
+    | */""" ==>
+  """/** Scaladoc should be retained.
+    |  * @param first line retains indent.
+    |  *     second line retains indent.
+    |  */
+    |"""
+
   """/** Foo
     |Bar
     |*Baz  */""" ==>


### PR DESCRIPTION
This fixes a long-standing bug in how comments get formatted if you have the suggested Scaladoc style enabled (both `MultilineScaladocCommentsStartOnFirstLine` and `PlaceScaladocAsterisksBeneathSecondAsterisk` set to `true`). Note the unit test commit, which fails on master.

This manifested if you had > 1 space leading a scaladoc comment. The worst part was that the formatting would only remove one space at a time - meaning each subsequence scalariform run deleted one additional space.