### PR TITLE
Remove trailing whitespace from non-Scaladoc comments.

### DIFF
--- a/scalariform/src/main/scala/scalariform/formatter/CommentFormatter.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/CommentFormatter.scala
@@ -34,7 +34,7 @@ trait CommentFormatter { self: HasFormattingPreferences with ScalaFormatter ⇒
 
   private def pruneEmptyFinal(lines: List[String]) = pruneEmptyInitial(lines.reverse).reverse
 
-  def formatComment(comment: HiddenToken, indentLevel: Int): String =
+  def formatScaladocComment(comment: HiddenToken, indentLevel: Int): String =
     if (comment.rawText contains '\n') {
       val sb = new StringBuilder
       val (start, rawLines) = getLines(comment.rawText)
@@ -64,4 +64,8 @@ trait CommentFormatter { self: HasFormattingPreferences with ScalaFormatter ⇒
     } else
       comment.rawText
 
+  /** Formats a non-Scaladoc comment by trimming trailing whitespace from each line. */
+  def formatNonScaladocComment(comment: HiddenToken, indentLevel: Int): String = {
+    comment.rawText.replaceAll("""\s+(\r?\n)""", "$1")
+  }
 }

--- a/scalariform/src/main/scala/scalariform/formatter/ScalaFormatter.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/ScalaFormatter.scala
@@ -194,16 +194,16 @@ abstract class ScalaFormatter extends HasFormattingPreferences with TypeFormatte
           val commentIndentLevel = if (nextTokenUnindents) indentLevel + 1 else indentLevel
           for ((previousOpt, hiddenToken, nextOpt) ← Utils.withPreviousAndNext(hiddenTokens)) {
             hiddenToken match {
-              case ScalaDocComment(token) ⇒
+              case ScalaDocComment(_) ⇒
                 builder.ensureAtBeginningOfLine()
                 builder.indent(commentIndentLevel, baseIndentOption)
-                builder.append(formatComment(hiddenToken, commentIndentLevel))
+                builder.append(formatScaladocComment(hiddenToken, commentIndentLevel))
               case SingleLineComment(_) | MultiLineComment(_) ⇒
                 if (builder.atBeginningOfLine)
                   builder.indent(commentIndentLevel, baseIndentOption)
                 else if (builder.atVisibleCharacter) // Separation from previous visible token
                   builder.append(" ")
-                builder.write(hiddenToken)
+                builder.append(formatNonScaladocComment(hiddenToken, commentIndentLevel))
               case Whitespace(token) ⇒
                 val newlineCount = token.text.count(_ == '\n')
                 val newlinesToWrite = previousOpt match {

--- a/scalariform/src/test/scala/scalariform/formatter/CommentFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/CommentFormatterTest.scala
@@ -99,6 +99,44 @@ class CommentFormatterTest extends AbstractFormatterTest {
     | */
     |"""
 
+  """/**
+    | * Trailing whitespace on this line and the line below should be stripped.   
+    | *    
+    | */
+    |""" ==>
+  """/**
+    | * Trailing whitespace on this line and the line below should be stripped.
+    | *
+    | */
+    |"""
+
+  """// Trailing whitespace in single-line comments should be stripped.   
+    |//  
+    |""" ==>
+  """// Trailing whitespace in single-line comments should be stripped.
+    |//
+    |"""
+
+  """/* Normal multi-line comment.
+    | * Trailing whitespace here should be stripped.   
+    | */
+    |""" ==>
+  """/* Normal multi-line comment.
+    | * Trailing whitespace here should be stripped.
+    | */
+    |"""
+
+  """/* 
+    |   Comment with trailing whitespace above.
+    |   Indent should be preserved, whitespace trimmed.
+    |   Visible separation (space below) should be added.
+    | */""" ==>
+  """/*
+    |   Comment with trailing whitespace above.
+    |   Indent should be preserved, whitespace trimmed.
+    |   Visible separation (space below) should be added.
+    | */ """
+
   {
   implicit val formattingPreferences = FormattingPreferences.setPreference(MultilineScaladocCommentsStartOnFirstLine, true)
 

--- a/scalariform/src/test/scala/scalariform/formatter/CommentFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/CommentFormatterTest.scala
@@ -100,8 +100,8 @@ class CommentFormatterTest extends AbstractFormatterTest {
     |"""
 
   """/**
-    | * Trailing whitespace on this line and the line below should be stripped.   
-    | *    
+    | * Trailing whitespace on this line and the line below should be stripped.\u0020\u0020
+    | *\u0020\u0020\u0020\u0020
     | */
     |""" ==>
   """/**
@@ -110,15 +110,15 @@ class CommentFormatterTest extends AbstractFormatterTest {
     | */
     |"""
 
-  """// Trailing whitespace in single-line comments should be stripped.   
-    |//  
+  """// Trailing whitespace in single-line comments should be stripped.\u0020\u0020
+    |//\u0020\u0020
     |""" ==>
   """// Trailing whitespace in single-line comments should be stripped.
     |//
     |"""
 
   """/* Normal multi-line comment.
-    | * Trailing whitespace here should be stripped.   
+    | * Trailing whitespace here should be stripped.\u0020\u0020
     | */
     |""" ==>
   """/* Normal multi-line comment.
@@ -126,7 +126,7 @@ class CommentFormatterTest extends AbstractFormatterTest {
     | */
     |"""
 
-  """/* 
+  """/*\u0020
     |   Comment with trailing whitespace above.
     |   Indent should be preserved, whitespace trimmed.
     |   Visible separation (space below) should be added.


### PR DESCRIPTION
Fixes #149 .

Note unit tests which will fail on `master`.