### PR TITLE
Make error message clearer when using --recurse if no files are found.

### DIFF
--- a/cli/src/main/scala/scalariform/commandline/Main.scala
+++ b/cli/src/main/scala/scalariform/commandline/Main.scala
@@ -129,7 +129,10 @@ object Main {
       errors ::= "Cannot specify files when using --stdin"
 
     if (files.isEmpty && !stdin)
-      errors ::= "Must specify a file or use --stdin (run with --help for full options)"
+      if (recurse)
+        errors ::= "No scala files found in directory or no directory specified"
+      else
+        errors ::= "Must specify a file or use --stdin (run with --help for full options)"
 
     if (forceOutput && !stdout && !stdin)
       errors ::= "--forceOutput can only be used with --stdout or --stdin"


### PR DESCRIPTION
This clarifies a very confusing error message.

Currently, when specifying a directory using `--recurse`, if the directory is empty or has no scala files in it, you get a message noting that you must specify a file or use --stdin.