### PR TITLE
Add an option to doubly-indent method parameters.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -388,6 +388,29 @@ Or:
 
 .. _recommended: http://docs.scala-lang.org/style/declarations.html#classes
 
+doubleIndentMethodDeclaration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``false``
+
+With this set to ``true``, method declarations will have an extra indentation
+added to their parameter list, if it spans multiple lines.
+This provides a visual distinction from the method body. For example::
+
+  def longMethodNameIsLong(paramOneNameIsLong: String, paramTwo: String,
+      paramThreeNameIsReallyLong): Unit = {
+    val startOfMethod = ...
+  }
+
+Or::
+
+  def longMethodNameIsLong(
+      paramOneNameIsLong: String,
+      paramTwoNameIsLong: String,
+      paramThreeNameIsLong): Unit = {
+    val startOfMethod = ...
+  }
+
 formatXml
 ~~~~~~~~~
 

--- a/formatterPreferences.properties
+++ b/formatterPreferences.properties
@@ -6,6 +6,7 @@ indentPackageBlocks=true
 formatXml=true
 preserveSpaceBeforeArguments=false
 doubleIndentClassDeclaration=false
+doubleIndentMethodDeclaration=false
 rewriteArrowSymbols=false
 alignSingleLineCaseStatements=true
 alignSingleLineCaseStatements.maxArrowIndent=40

--- a/scalariform/src/main/scala/scalariform/formatter/ExprFormatter.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/ExprFormatter.scala
@@ -934,7 +934,8 @@ trait ExprFormatter { self: HasFormattingPreferences with AnnotationFormatter wi
     val FunDefOrDcl(_, _, typeParamClauseOpt, paramClauses, returnTypeOpt, funBodyOpt, _) = funDefOrDcl
     for (typeParamClause ← typeParamClauseOpt)
       formatResult ++= format(typeParamClause.contents)
-    formatResult ++= formatParamClauses(paramClauses)
+    val doubleIndentParams = formattingPreferences(DoubleIndentMethodDeclaration)
+    formatResult ++= formatParamClauses(paramClauses, doubleIndentParams)
     for ((colon, type_) ← returnTypeOpt)
       formatResult ++= format(type_)
     for (funBody ← funBodyOpt) {

--- a/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
@@ -94,7 +94,7 @@ object AllPreferences {
     PreserveSpaceBeforeArguments, AlignParameters, AlignArguments, DoubleIndentClassDeclaration, FormatXml, IndentPackageBlocks,
     AlignSingleLineCaseStatements, AlignSingleLineCaseStatements.MaxArrowIndent, IndentLocalDefs, PreserveDanglingCloseParenthesis, DanglingCloseParenthesis,
     SpaceInsideParentheses, SpaceInsideBrackets, SpacesWithinPatternBinders, MultilineScaladocCommentsStartOnFirstLine, IndentWithTabs,
-    CompactControlReadability, PlaceScaladocAsterisksBeneathSecondAsterisk, SpacesAroundMultiImports
+    CompactControlReadability, PlaceScaladocAsterisksBeneathSecondAsterisk, DoubleIndentMethodDeclaration, SpacesAroundMultiImports
   )
 
   val preferencesByKey: Map[String, PreferenceDescriptor[_]] =
@@ -149,6 +149,12 @@ case object AlignArguments extends BooleanPreferenceDescriptor {
 case object DoubleIndentClassDeclaration extends BooleanPreferenceDescriptor {
   val key = "doubleIndentClassDeclaration"
   val description = "Double indent either a class's parameters or its inheritance list"
+  val defaultValue = false
+}
+
+case object DoubleIndentMethodDeclaration extends BooleanPreferenceDescriptor {
+  val key = "doubleIndentMethodDeclaration"
+  val description = "Double indent a method's parameters, if they span multiple lines"
   val defaultValue = false
 }
 

--- a/scalariform/src/test/scala/scalariform/formatter/DoubleIndentMethodFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/DoubleIndentMethodFormatterTest.scala
@@ -1,0 +1,94 @@
+package scalariform.formatter
+
+import scalariform.parser._
+import scalariform.formatter.preferences._
+
+// format: OFF
+class DoubleIndentMethodFormatterTest extends AbstractFormatterTest {
+
+  override val debug = false
+
+  {
+
+  implicit val formattingPreferences =
+    FormattingPreferences.setPreference(DoubleIndentMethodDeclaration, true)
+
+  // Test basic formatting for regressions.
+  "def foo" ==> "def foo"
+
+  "def foo=42" ==> "def foo = 42"
+
+  "def foo()" ==> "def foo()"
+
+  "def foo(n:Int)" ==> "def foo(n: Int)"
+
+  """def foo(n: Int
+  |)""" ==>
+  "def foo(n: Int)"
+
+  "def foo( n:Int,m:String )" ==> "def foo(n: Int, m: String)"
+
+  "def foo{doStuff()}" ==> "def foo { doStuff() }"
+
+  "def foo(x_ : Int)" ==> "def foo(x_ : Int)"
+
+  """def a
+    |: String""" ==>
+  """def a: String"""
+
+ """def a()
+    |{
+    |b
+    |  }""" ==>
+  """def a() {
+    |  b
+    |}"""
+
+  """def a[B,
+    |C]
+    |()""" ==>
+  """def a[B, C]()"""
+
+  // Verify that continued parameters are maintained & doubly-indented.
+  """def foo(
+    |  a: String)""" ==>
+  """def foo(
+    |    a: String
+    |)"""
+
+  // TODO: Broken until https://github.com/scala-ide/scalariform/issues/187 is fixed.
+  """def foo(a: String,
+    |  b: String)""" =/=>
+  """def foo(
+    |    a: String,
+    |    b: String
+    |)"""
+
+  // TODO: Broken until https://github.com/scala-ide/scalariform/issues/187 is fixed.
+  """def foo(a: String,
+    |      b: String)""" =/=>
+  """def foo(
+    |    a: String,
+    |    b: String
+    |)"""
+
+  """def foo(a: String, b: String,
+    |    c: String)""" ==>
+  """def foo(a: String, b: String,
+    |    c: String)"""
+
+  """def foo(
+    |    a: String,
+    |      b: String)""" ==>
+  """def foo(
+    |    a: String,
+    |    b: String
+    |)"""
+  }
+
+  def parse(parser: ScalaParser) = parser.nonLocalDefOrDcl()
+
+  type Result = FullDefOrDcl
+
+  def format(formatter: ScalaFormatter, result: Result) = formatter.format(result)(FormatterState(indentLevel = 0))
+}


### PR DESCRIPTION
Fixes https://github.com/scala-ide/scalariform/issues/122 (by adding a formatting option).

(Re-opening https://github.com/daniel-trinh/scalariform/pull/33)