### PR TITLE
Update double class indentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -352,23 +352,22 @@ Default: ``false``
 With this set to ``true``, class (and trait / object) declarations
 will be formatted as recommended_ by the Scala Style Guide. That is,
 if the declaration section spans multiple lines, it will be formatted
-so that either the parameter section or the inheritance section is
-doubly indented. This provides a visual distinction from the members
-of the class. For example:
+so that the parameter section is doubly indented. This provides a visual
+distinction between the constructor arguments & the extensions. For example:
 
 .. code:: scala
 
   class Person(
-    name: String,
-    age: Int,
-    birthdate: Date,
-    astrologicalSign: String,
-    shoeSize: Int,
-    favoriteColor: java.awt.Color)
-      extends Entity
-      with Logging
-      with Identifiable
-      with Serializable {
+      name: String,
+      age: Int,
+      birthdate: Date,
+      astrologicalSign: String,
+      shoeSize: Int,
+      favoriteColor: java.awt.Color)
+    extends Entity
+    with Logging
+    with Identifiable
+    with Serializable {
     def firstMethod = ...
   }
 

--- a/scalariform/src/main/scala/scalariform/formatter/TemplateFormatter.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/TemplateFormatter.scala
@@ -1,9 +1,8 @@
 package scalariform.formatter
 
-import scalariform.lexer.Token
-
-import scalariform.parser._
 import scalariform.formatter.preferences._
+import scalariform.lexer.Token
+import scalariform.parser._
 
 trait TemplateFormatter { self: HasFormattingPreferences with AnnotationFormatter with HasHiddenTokenInfo with TypeFormatter with ExprFormatter with ScalaFormatter ⇒
 
@@ -30,15 +29,11 @@ trait TemplateFormatter { self: HasFormattingPreferences with AnnotationFormatte
     } {
       if (annotations.size > 0)
         formatResult = formatResult.formatNewlineOrOrdinary(firstToken, CompactEnsuringGap)
-      val doubleIndentParams = formattingPreferences(DoubleIndentClassDeclaration) &&
-        !templateInheritanceSectionOpt.exists { section ⇒ containsNewline(section) || hiddenPredecessors(section.firstToken).containsNewline } &&
-        templateBodyOption.exists(containsNewline(_))
+      val doubleIndentParams = formattingPreferences(DoubleIndentClassDeclaration)
       formatResult ++= formatParamClauses(paramClauses, doubleIndentParams)
     }
     for (TemplateInheritanceSection(extendsOrSubtype, earlyDefsOpt, templateParentsOpt) ← templateInheritanceSectionOpt) {
-      val doubleIndentTemplateInheritance = formattingPreferences(DoubleIndentClassDeclaration) &&
-        (templateBodyOption.exists(containsNewline(_)) || paramClausesOpt.exists(containsNewline(_)))
-      val inheritanceIndent = if (doubleIndentTemplateInheritance) 2 else 1
+      val inheritanceIndent = 1
       var currentFormatterState = formatterState
       if (hiddenPredecessors(extendsOrSubtype).containsNewline) {
         currentFormatterState = formatterState.indent(inheritanceIndent)

--- a/scalariform/src/test/scala/scalariform/formatter/DoubleIndentClassDeclaration.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/DoubleIndentClassDeclaration.scala
@@ -82,5 +82,15 @@ class DoubleIndentClassDeclaration extends AbstractFormatterTest {
     |  println("d")
     |}"""
 
+  """class Person(
+    |  name: String,
+    |  age: Int)
+    |    extends Entity with Logging""" ==>
+  """class Person(
+    |    name: String,
+    |    age: Int
+    |)
+    |  extends Entity with Logging"""
+
 }
 

--- a/scalariform/src/test/scala/scalariform/formatter/DoubleIndentClassDeclaration.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/DoubleIndentClassDeclaration.scala
@@ -1,0 +1,86 @@
+package scalariform.formatter
+
+import scalariform.formatter.preferences._
+import scalariform.parser._
+
+class DoubleIndentClassDeclaration extends AbstractFormatterTest {
+
+  override val debug = false
+
+  def parse(parser: ScalaParser) = parser.nonLocalDefOrDcl()
+
+  type Result = FullDefOrDcl
+
+  def format(formatter: ScalaFormatter, result: Result) = formatter.format(result)(FormatterState(indentLevel = 0))
+
+  implicit val formattingPreferences = FormattingPreferences.setPreference(DoubleIndentClassDeclaration, true)
+  """class Person(
+    |  name: String,
+    |  age: Int)
+    |    extends Entity
+    |    with Logging
+    |    with Identifiable
+    |    with Serializable""" ==>
+  """class Person(
+    |    name: String,
+    |    age: Int
+    |)
+    |  extends Entity
+    |  with Logging
+    |  with Identifiable
+    |  with Serializable"""
+
+  """class Person(
+    |    name: String,
+    |    age: Int) {
+    |  def firstMethod = 42
+    |}""" ==>
+  """class Person(
+    |    name: String,
+    |    age: Int
+    |) {
+    |  def firstMethod = 42
+    |}"""
+
+  """class Person(name: String, age: Int, birthdate: Date, astrologicalSign: String, shoeSize: Int, favoriteColor: java.awt.Color)
+    |extends Entity
+    |with Logging
+    |with Identifiable
+    |with Serializable {
+    |def firstMethod = 42
+    |}""" ==>
+  """class Person(name: String, age: Int, birthdate: Date, astrologicalSign: String, shoeSize: Int, favoriteColor: java.awt.Color)
+    |  extends Entity
+    |  with Logging
+    |  with Identifiable
+    |  with Serializable {
+    |  def firstMethod = 42
+    |}"""
+
+  """class Person(
+    |name: String,
+    |  age: Int)
+    |extends Entity  {
+    |def method() = 42
+    |}""" ==>
+  """class Person(
+    |    name: String,
+    |    age: Int
+    |)
+    |  extends Entity {
+    |  def method() = 42
+    |}"""
+
+  """trait A
+    |extends B
+    |with C {
+    |println("d")
+    |}""" ==>
+  """trait A
+    |  extends B
+    |  with C {
+    |  println("d")
+    |}"""
+
+}
+

--- a/scalariform/src/test/scala/scalariform/formatter/TemplateFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/TemplateFormatterTest.scala
@@ -1,7 +1,7 @@
 package scalariform.formatter
 
-import scalariform.parser._
 import scalariform.formatter.preferences._
+import scalariform.parser._
 
 // format: OFF
 class TemplateFormatterTest extends AbstractFormatterTest {
@@ -613,78 +613,6 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |)(c: {
     |  val d: Int
     |})"""
-
-  {
-    implicit val formattingPreferences = FormattingPreferences.setPreference(DoubleIndentClassDeclaration, true)
-    """class Person(
-      |  name: String,
-      |  age: Int)
-      |    extends Entity
-      |    with Logging
-      |    with Identifiable
-      |    with Serializable""" ==>
-    """class Person(
-      |  name: String,
-      |  age: Int
-      |)
-      |    extends Entity
-      |    with Logging
-      |    with Identifiable
-      |    with Serializable"""
-
-    """class Person(
-      |    name: String,
-      |    age: Int) {
-      |  def firstMethod = 42
-      |}""" ==>
-    """class Person(
-      |    name: String,
-      |    age: Int
-      |) {
-      |  def firstMethod = 42
-      |}"""
-
-  """class Person(name: String, age: Int, birthdate: Date, astrologicalSign: String, shoeSize: Int, favoriteColor: java.awt.Color)
-    |extends Entity
-    |with Logging
-    |with Identifiable
-    |with Serializable {
-    |def firstMethod = 42
-    |}""" ==>
-  """class Person(name: String, age: Int, birthdate: Date, astrologicalSign: String, shoeSize: Int, favoriteColor: java.awt.Color)
-    |    extends Entity
-    |    with Logging
-    |    with Identifiable
-    |    with Serializable {
-    |  def firstMethod = 42
-    |}"""
-
-    """class Person(
-      |name: String,
-      |  age: Int)
-      |extends Entity  {
-      |def method() = 42
-      |}""" ==>
-    """class Person(
-      |  name: String,
-      |  age: Int
-      |)
-      |    extends Entity {
-      |  def method() = 42
-      |}"""
-
-  """trait A
-    |extends B
-    |with C {
-    |println("d")
-    |}""" ==>
-  """trait A
-    |    extends B
-    |    with C {
-    |  println("d")
-    |}"""
-
-  }
 
   "trait Function1[@specialized(Int, Long, Double) -T1, @specialized(Unit, Int, Long, Double) +R] extends AnyRef" ==>
   "trait Function1[@specialized(Int, Long, Double) -T1, @specialized(Unit, Int, Long, Double) +R] extends AnyRef"


### PR DESCRIPTION
reviving https://github.com/daniel-trinh/scalariform/pull/38

The current version of the Scala style guide prescribes indenting multi-line constructor arguments 4 spaces, with extensions indented 2: http://docs.scala-lang.org/style/declarations.html#classes

Also splits tests for DoubleIndentClassDeclaration into its own file
