### PR TITLE
Ensure spaces around the colon in context bound declarations.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -591,17 +591,34 @@ spaceBeforeColon
 
 Default: ``false``
 
-Whether to ensure a space before colon. For example, if ``false``, then:
+Whether to ensure a space before all single colons. For example, if ``false``, then:
 
 .. code:: scala
 
-  def add(a: Int, b: Int): Int = a + b
+  def add[T: Numeric](a: T, b: T): Int = implictly[Numeric[T]].plus(a, b)
 
 If ``true``, then:
 
 .. code:: scala
 
-  def add(a : Int, b : Int) : Int = a + b
+  def add[T : Numeric](a : T, b : T): Int = implictly[Numeric[T]].plus(a, b)
+
+spaceBeforeContextColon
+~~~~~~~~~~~~~~~~
+
+Default: ``false``
+
+Whether to ensure a space before colons in context bounds (the typeclass pattern). For example, if ``false``, then:
+
+.. code:: scala
+
+  def newArray[T: ClassManifest](n: Int) = new Array[T](n)
+
+If ``true``, then:
+
+.. code:: scala
+
+  def newArray[T : ClassManifest](n: Int) = new Array[T](n)
 
 spaceInsideBrackets
 ~~~~~~~~~~~~~~~~~~~

--- a/scalariform/src/main/scala/scalariform/formatter/TypeFormatter.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/TypeFormatter.scala
@@ -31,8 +31,13 @@ trait TypeFormatter { self: HasFormattingPreferences with AnnotationFormatter wi
       else if (element.isInstanceOf[VarargsTypeElement]) {
         val instruction = if (Chars.isOperatorPart(previousElement.lastToken.text.last)) CompactEnsuringGap else Compact
         formatResult = formatResult.before(element.firstToken, instruction)
-      } else if (element.lastToken.tokenType == Tokens.COLON && element.tokens.tail.headOption.isEmpty) {
+      } else if (element.lastToken.tokenType == Tokens.COLON &&
+        element.tokens.tail.isEmpty &&
+        formattingPreferences(SpaceBeforeContextColon)) {
         // Type class - [A : B]. Ensure a gap.
+        // TODO: If we are OK breaking backwards-compatibility, it would be better to move the
+        // SpaceBeforeContextColon check here, so that the SpaceBeforeColon setting would only
+        // apply to colons outside of type parameters.
         formatResult = formatResult.before(element.lastToken, CompactEnsuringGap)
       }
       //      else if (previousElement.isInstanceOf[CallByNameTypeElement])

--- a/scalariform/src/main/scala/scalariform/formatter/TypeFormatter.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/TypeFormatter.scala
@@ -31,6 +31,9 @@ trait TypeFormatter { self: HasFormattingPreferences with AnnotationFormatter wi
       else if (element.isInstanceOf[VarargsTypeElement]) {
         val instruction = if (Chars.isOperatorPart(previousElement.lastToken.text.last)) CompactEnsuringGap else Compact
         formatResult = formatResult.before(element.firstToken, instruction)
+      } else if (element.lastToken.tokenType == Tokens.COLON && element.tokens.tail.headOption.isEmpty) {
+        // Type class - [A : B]. Ensure a gap.
+        formatResult = formatResult.before(element.lastToken, CompactEnsuringGap)
       }
       //      else if (previousElement.isInstanceOf[CallByNameTypeElement])
       //  formatResult = formatResult.before(element.firstToken, Compact)

--- a/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
@@ -90,7 +90,7 @@ trait IntegerPreferenceDescriptor extends PreferenceDescriptor[Int] {
 
 object AllPreferences {
   val preferences: List[PreferenceDescriptor[_]] = List(
-    RewriteArrowSymbols, IndentSpaces, SpaceBeforeColon, CompactStringConcatenation,
+    RewriteArrowSymbols, IndentSpaces, SpaceBeforeColon, SpaceBeforeContextColon, CompactStringConcatenation,
     PreserveSpaceBeforeArguments, AlignParameters, AlignArguments, DoubleIndentClassDeclaration, FormatXml, IndentPackageBlocks,
     AlignSingleLineCaseStatements, AlignSingleLineCaseStatements.MaxArrowIndent, IndentLocalDefs, PreserveDanglingCloseParenthesis, DanglingCloseParenthesis,
     SpaceInsideParentheses, SpaceInsideBrackets, SpacesWithinPatternBinders, MultilineScaladocCommentsStartOnFirstLine, IndentWithTabs,
@@ -119,6 +119,12 @@ case object IndentSpaces extends IntegerPreferenceDescriptor {
 case object SpaceBeforeColon extends BooleanPreferenceDescriptor {
   val key = "spaceBeforeColon"
   val description = "Add a space before colons"
+  val defaultValue = false
+}
+
+case object SpaceBeforeContextColon extends BooleanPreferenceDescriptor {
+  val key = "spaceBeforeContextColon"
+  val description = "Add a space before colons in context bounds"
   val defaultValue = false
 }
 

--- a/scalariform/src/test/scala/scalariform/formatter/DefOrDclFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/DefOrDclFormatterTest.scala
@@ -104,6 +104,35 @@ class DefOrDclFormatterTest extends AbstractFormatterTest {
   """private[a] sealed trait B"""
 
   {
+  // Typeclass formatting should not be affected by the SpaceBeforeColon setting.
+  implicit val formattingPreferences = FormattingPreferences.setPreference(SpaceBeforeColon, false)
+
+  """class Foo[A : B]() {}""" ==>
+  """class Foo[A : B]() {}"""
+
+  """def foo[A : B]()""" ==>
+  """def foo[A : B]()"""
+
+  """def foo[A: B :C]()""" ==>
+  """def foo[A : B : C]()"""
+
+  }
+  {
+  // Typeclass formatting should not be affected by the SpaceBeforeColon setting.
+  implicit val formattingPreferences = FormattingPreferences.setPreference(SpaceBeforeColon, true)
+
+  """class Foo[A : B]() {}""" ==>
+  """class Foo[A : B]() {}"""
+
+  """def foo[A : B]()""" ==>
+  """def foo[A : B]()"""
+
+  """def foo[A: B :C]()""" ==>
+  """def foo[A : B : C]()"""
+
+  }
+
+  {
 
   implicit val formattingPreferences =
     FormattingPreferences

--- a/scalariform/src/test/scala/scalariform/formatter/DefOrDclFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/DefOrDclFormatterTest.scala
@@ -103,9 +103,28 @@ class DefOrDclFormatterTest extends AbstractFormatterTest {
     |sealed trait B""" ==>
   """private[a] sealed trait B"""
 
+  """class Foo[A : B]() {}""" ==>
+  """class Foo[A: B]() {}"""
+
+  """def foo[A : B]()""" ==>
+  """def foo[A: B]()"""
+
+  """def foo[A: B :C]()""" ==>
+  """def foo[A: B: C]()"""
+
+  {
+  // SpaceBeforeColon should add a space for the context colon (for backwards-compatibility).
+  implicit val formattingPreferences =
+    FormattingPreferences.setPreference(SpaceBeforeColon, true).setPreference(SpaceBeforeContextColon, false)
+
+  """class Foo[A : B]() {}""" ==>
+  """class Foo[A : B]() {}"""
+  }
+
   {
   // Typeclass formatting should not be affected by the SpaceBeforeColon setting.
-  implicit val formattingPreferences = FormattingPreferences.setPreference(SpaceBeforeColon, false)
+  implicit val formattingPreferences =
+    FormattingPreferences.setPreference(SpaceBeforeColon, false).setPreference(SpaceBeforeContextColon, true)
 
   """class Foo[A : B]() {}""" ==>
   """class Foo[A : B]() {}"""
@@ -119,7 +138,8 @@ class DefOrDclFormatterTest extends AbstractFormatterTest {
   }
   {
   // Typeclass formatting should not be affected by the SpaceBeforeColon setting.
-  implicit val formattingPreferences = FormattingPreferences.setPreference(SpaceBeforeColon, true)
+  implicit val formattingPreferences =
+    FormattingPreferences.setPreference(SpaceBeforeColon, true).setPreference(SpaceBeforeContextColon, true)
 
   """class Foo[A : B]() {}""" ==>
   """class Foo[A : B]() {}"""


### PR DESCRIPTION
Fixes https://github.com/scala-ide/scalariform/issues/135 .

This does change default behavior, but fixes what should be considered a bug.

Today, if you have a type declaration like:
```scala
def foo[W<%T1,X<:T2,Y>:T3,Z:T4]()
```
Scalariform will format as:
```scala
// Note spaces around all bounds *except* the context bound, after the `Z`.
 def foo[W <% T1, X <: T2, Y >: T3, Z: T4]()
```
This fix ensures spaces around the single `:`.