### PR TITLE
Change `spacesAroundMultiImports` default setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -678,7 +678,7 @@ If ``false``,:
 spacesAroundMultiImports
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Default: ``false``
+Default: ``true``
 
 Whether or not to add spaces around multi-imports.
 For example, if ``false``, then:
@@ -695,11 +695,7 @@ If ``true``, then:
   import a.{ b, c, d }
   import foo.{ bar => baz }
 
-Older versions of `Scalariform` used ``true``,
-but the standard Scala formatting requires ``false``.
-
-See the examples given in "Chapter 13 - Packages and Imports.", page 244 of *Programming in Scala*
-2nd ed. (2010) by Odersky, Spoon and Venners.
+Compatibility note: Versions 0.1.6 & 0.1.7 of `Scalariform` used ``false``.
 
 Scala Style Guide
 ~~~~~~~~~~~~~~~~~

--- a/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
@@ -249,7 +249,7 @@ case object PlaceScaladocAsterisksBeneathSecondAsterisk extends BooleanPreferenc
 case object SpacesAroundMultiImports extends BooleanPreferenceDescriptor {
   val key = "spacesAroundMultiImports"
   val description = "Place spaces around multi imports (import a.{ b, c, d }"
-  val defaultValue = false
+  val defaultValue = true
 }
 
 case object NewlineAtEndOfFile extends BooleanPreferenceDescriptor {


### PR DESCRIPTION
This is backwards-compatible with the pre-`daniel-trinh` fork.