### PR TITLE
Update default for `danglingCloseParenthesis`.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -549,7 +549,7 @@ Otherwise, if ``false``, spaces before arguments will always be removed.
 danglingCloseParenthesis
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Default: ``Preserve``
+Default: ``Prevent``
 
 If ``Force``, any closing parentheses will be set to dangle. For example:
 

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ sbt will build one jar with all the dependencies and put it in ::
 
 You can copy this to a location in your path and execute it as follows: ::
 
-   java -jar /home/me/bin/cli-assembly-$scalariform_version.jar -f -q +compactControlReadability +alignParameters +alignSingleLineCaseStatements +doubleIndentClassDeclaration +preserveDanglingCloseParenthesis +rewriteArrowSymbols +preserveSpaceBeforeArguments --stdout ~/myproject/src/main/scala/Stuff.scala > Stuff.scala
+   java -jar /home/me/bin/cli-assembly-$scalariform_version.jar -f -q +compactControlReadability +alignParameters +alignSingleLineCaseStatements +doubleIndentClassDeclaration +rewriteArrowSymbols +preserveSpaceBeforeArguments --stdout ~/myproject/src/main/scala/Stuff.scala > Stuff.scala
 
 Integration with sbt
 --------------------
@@ -133,11 +133,11 @@ While there is no specific Vim integration at present, you can use
 Scalariform as an external formatter for the ``gq`` command by adding
 the following to ``.vimrc`` ::
 
-  au BufEnter *.scala setl formatprg=java\ -jar\ /home/me/bin/scalariform.jar\ -f\ -q\ +compactControlReadability\ +alignParameters\ +alignSingleLineCaseStatements\ +doubleIndentClassDeclaration\ +preserveDanglingCloseParenthesis\ +rewriteArrowSymbols\ +preserveSpaceBeforeArguments\ --stdin\ --stdout
+  au BufEnter *.scala setl formatprg=java\ -jar\ /home/me/bin/scalariform.jar\ -f\ -q\ +compactControlReadability\ +alignParameters\ +alignSingleLineCaseStatements\ +doubleIndentClassDeclaration\ +rewriteArrowSymbols\ +preserveSpaceBeforeArguments\ --stdin\ --stdout
 
 Or, if you don't like escaping spaces, you can set up a mapping: ::
 
-    map ,st :%!java -jar /home/me/bin/scalariform.jar -f -q +compactControlReadability +alignParameters +alignSingleLineCaseStatements +doubleIndentClassDeclaration +preserveDanglingCloseParenthesis +rewriteArrowSymbols +preserveSpaceBeforeArguments --stdin --stdout <CR>
+    map ,st :%!java -jar /home/me/bin/scalariform.jar -f -q +compactControlReadability +alignParameters +alignSingleLineCaseStatements +doubleIndentClassDeclaration +rewriteArrowSymbols +preserveSpaceBeforeArguments --stdin --stdout <CR>
 
 You can create your own executable scalariform.jar by following the instructions at the top of this file, in "Packaging an executable JAR."
 
@@ -549,7 +549,7 @@ Otherwise, if ``false``, spaces before arguments will always be removed.
 danglingCloseParenthesis
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Default: ``Force``
+Default: ``Preserve``
 
 If ``Force``, any closing parentheses will be set to dangle. For example:
 

--- a/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
@@ -201,7 +201,7 @@ case object PreserveDanglingCloseParenthesis extends BooleanPreferenceDescriptor
 case object DanglingCloseParenthesis extends IntentPreferenceDescriptor {
   val key = "danglingCloseParenthesis"
   val description = "Put a newline before a ')' in an argument expression"
-  val defaultValue = Preserve
+  val defaultValue = Prevent
 }
 
 case object SpaceInsideParentheses extends BooleanPreferenceDescriptor {

--- a/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
@@ -201,7 +201,7 @@ case object PreserveDanglingCloseParenthesis extends BooleanPreferenceDescriptor
 case object DanglingCloseParenthesis extends IntentPreferenceDescriptor {
   val key = "danglingCloseParenthesis"
   val description = "Put a newline before a ')' in an argument expression"
-  val defaultValue = Force
+  val defaultValue = Preserve
 }
 
 case object SpaceInsideParentheses extends BooleanPreferenceDescriptor {

--- a/scalariform/src/test/scala/scalariform/formatter/DoubleIndentMethodFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/DoubleIndentMethodFormatterTest.scala
@@ -55,19 +55,20 @@ class DoubleIndentMethodFormatterTest extends AbstractFormatterTest {
   """def foo(
     |    a: String)"""
 
+  // TODO: Broken until https://github.com/scala-ide/scalariform/issues/187 is fixed.
   """def foo(a: String,
     |  b: String)""" =/=>
   """def foo(
     |    a: String,
     |    b: String)"""
 
+  // TODO: Broken until https://github.com/scala-ide/scalariform/issues/187 is fixed.
   """def foo(a: String,
     |      b: String
     |)""" =/=>
   """def foo(
     |    a: String,
-    |    b: String
-    |)"""
+    |    b: String)"""
 
   """def foo(a: String, b: String,
     |    c: String)""" ==>

--- a/scalariform/src/test/scala/scalariform/formatter/DoubleIndentMethodFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/DoubleIndentMethodFormatterTest.scala
@@ -53,20 +53,17 @@ class DoubleIndentMethodFormatterTest extends AbstractFormatterTest {
   """def foo(
     |  a: String)""" ==>
   """def foo(
-    |    a: String
-    |)"""
+    |    a: String)"""
 
-  // TODO: Broken until https://github.com/scala-ide/scalariform/issues/187 is fixed.
   """def foo(a: String,
     |  b: String)""" =/=>
   """def foo(
     |    a: String,
-    |    b: String
-    |)"""
+    |    b: String)"""
 
-  // TODO: Broken until https://github.com/scala-ide/scalariform/issues/187 is fixed.
   """def foo(a: String,
-    |      b: String)""" =/=>
+    |      b: String
+    |)""" =/=>
   """def foo(
     |    a: String,
     |    b: String
@@ -82,8 +79,7 @@ class DoubleIndentMethodFormatterTest extends AbstractFormatterTest {
     |      b: String)""" ==>
   """def foo(
     |    a: String,
-    |    b: String
-    |)"""
+    |    b: String)"""
   }
 
   def parse(parser: ScalaParser) = parser.nonLocalDefOrDcl()

--- a/scalariform/src/test/scala/scalariform/formatter/ForExprFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/ForExprFormatterTest.scala
@@ -137,15 +137,13 @@ class ForExprFormatterTest extends AbstractExpressionFormatterTest {
     |yield n)""" ==>
   """Some(
     |  for (n <- 1 to 10)
-    |    yield n
-    |)"""
+    |    yield n)"""
 
   """Some(
     |for (n <- 1 to 10)
     |proc())""" ==>
   """Some(
     |  for (n <- 1 to 10)
-    |    proc()
-    |)"""
+    |    proc())"""
 
 }

--- a/scalariform/src/test/scala/scalariform/formatter/IndentWithTabsTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/IndentWithTabsTest.scala
@@ -48,8 +48,7 @@ class IndentWithTabsTest extends AbstractFormatterTest {
   """foo(
     |\talpha = "foo",
     |\tbeta = "bar",
-    |\tgamma = false
-    |)""".replace("\\t", "\t")
+    |\tgamma = false)""".replace("\\t", "\t")
 
   """foo(
     |"foo",
@@ -58,8 +57,7 @@ class IndentWithTabsTest extends AbstractFormatterTest {
   """foo(
     |\t"foo",
     |\t"bar",
-    |\tfalse
-    |)""".replace("\\t", "\t")
+    |\tfalse)""".replace("\\t", "\t")
 
   {
     implicit val formattingPreferences = FormattingPreferences
@@ -114,11 +112,13 @@ class IndentWithTabsTest extends AbstractFormatterTest {
     """foo(
       |"foo",
       |"bar",
-      |false)""" ==>
+      |false
+      |)""" ==>
     """foo(
       |\t"foo",
       |\t"bar",
-      |\tfalse)""".replace("\\t", "\t")
+      |\tfalse
+      |)""".replace("\\t", "\t")
 
     """foo(
       |\t"foo",

--- a/scalariform/src/test/scala/scalariform/formatter/MiscExpressionFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/MiscExpressionFormatterTest.scala
@@ -301,15 +301,15 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
     |2)""" ==>
   """foo(
     |  1,
-    |  2
-    |)"""
+    |  2)"""
 
    """/* a */
      |b""" ==>
    """/* a */ b"""
 
   """a(
-    |if (b) c)""" ==>
+    |if (b) c
+    |)""" ==>
   """a(
     |  if (b) c
     |)"""
@@ -319,8 +319,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
     |c)""" ==>
   """a(
     |  if (b)
-    |    c
-    |)"""
+    |    c)"""
 
   """a("A",
     |  b("B",
@@ -333,26 +332,21 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
     |  b(
     |    "B",
     |    c(1, 2),
-    |    c(3, 4)
-    |  ),
+    |    c(3, 4)),
     |  b(
     |    "B2",
-    |    c(5, 6)
-    |  )
-    |)"""
+    |    c(5, 6)))"""
 
   """1 + (a,
     | b, c)""" ==>
   """1 + (
     |  a,
-    |  b, c
-    |)"""
+    |  b, c)"""
 
    """1 + (
      |  a, b, c)""" ==>
    """1 + (
-     |  a, b, c
-     |)"""
+     |  a, b, c)"""
 
    """1 + (a
      |, b, c)""" ==>
@@ -401,8 +395,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
     |/* c */d)""" ==>
     """a(
       |  b,
-      |  /* c */ d
-      |)"""
+      |  /* c */ d)"""
 
    """submit(
      |
@@ -425,8 +418,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
     |  b,
     |  c => {
     |    d
-    |  }
-    |)"""
+    |  })"""
 
   """a(b,
     |(c), {
@@ -435,16 +427,14 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
     |  b,
     |  (c), {
     |    d
-    |  }
-    |)"""
+    |  })"""
 
   """a(
     |    () =>
     |    b)""" ==>
   """a(
     |  () =>
-    |    b
-    |)"""
+    |    b)"""
 
   """Book(
     |  name = "Name",
@@ -466,8 +456,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
     |  (1, 2),
     |  (3, 4),
     |  (5, 6),
-    |  (7, 8)
-    |)"""
+    |  (7, 8))"""
 
    """(1
      |,2)""" ==>
@@ -484,8 +473,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
   """a(
     |  b,
     |  c +
-    |    d
-    |)"""
+    |    d)"""
 
    """(a ->
      |new B)""" ==>
@@ -576,8 +564,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
      |d))""" ==>
    """a()
      |  .b(c(
-     |    d
-     |  ))"""
+     |    d))"""
 
    """a().
      |b(c => {
@@ -673,8 +660,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
      |}""" ==>
    """a(
      |  b,
-     |  c
-     |) + {
+     |  c) + {
      |  d
      |}"""
 
@@ -683,8 +669,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
      |d}""" ==>
    """(
      |  b,
-     |  c
-     |) + {
+     |  c) + {
      |    d
      |  }"""
 
@@ -720,14 +705,11 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
      | f) + g""" ==>
    """(
      |  a,
-     |  b
-     |) + (
+     |  b) + (
      |    c,
-     |    d
-     |  ) + (
+     |    d) + (
      |      e,
-     |      f
-     |    ) + g"""
+     |      f) + g"""
 
     """(a, b)""" ==> """(a, b)"""
    """a + (b,
@@ -735,8 +717,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
      |d""" ==>
    """a + (
      |  b,
-     |  c
-     |) +
+     |  c) +
      |  d"""
 
    """a + f(b,
@@ -744,8 +725,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
      |d""" ==>
    """a + f(
      |  b,
-     |  c
-     |) +
+     |  c) +
      |  d"""
 
    """a
@@ -754,8 +734,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
      |.d""" ==>
    """a
      |  .b(
-     |    c
-     |  )
+     |    c)
      |  .d"""
 
    "Foo.this" ==> "Foo.this"
@@ -839,8 +818,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
        """Method(
          |  aaa = "",
          |  bb  = 1,
-         |  c   = null
-         |)"""
+         |  c   = null)"""
 
        """method(multiLineArgument = {
          |  val string = "hello world"
@@ -937,10 +915,13 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
 
       """multiClause(
          |  arg1 = 1,
-         |  argument2 = 2)(
+         |  argument2 = 2
+         |)(
          |  args3 = 3,
-         |  arg4 = 4)(
-         |  arg5 = 5)""" ==>
+         |  arg4 = 4
+         |)(
+         |  arg5 = 5
+         |)""" ==>
       """multiClause(
          |  arg1      = 1,
          |  argument2 = 2
@@ -952,9 +933,11 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
          |)"""
 
    """a(
-      |b = c)(
+      |b = c
+      |)(
       |c,
-      |d)(
+      |d
+      |)(
       |d)""" ==>
       """a(
         |  b = c
@@ -962,8 +945,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
         |  c,
         |  d
         |)(
-        |  d
-        |)"""
+        |  d)"""
 
    """Nested0(
        |  arg1   = Nested1(abcccc = 1,

--- a/scalariform/src/test/scala/scalariform/formatter/MiscExpressionFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/MiscExpressionFormatterTest.scala
@@ -311,8 +311,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
     |if (b) c
     |)""" ==>
   """a(
-    |  if (b) c
-    |)"""
+    |  if (b) c)"""
 
   """a(
     |if (b)
@@ -408,8 +407,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
     |)""" ==>
   """(
     |  42,
-    |  46
-    |)""" // I prefer no initial indent for tuples, although you could argue it should be consistent with ParenExprs
+    |  46)""" // I prefer no initial indent for tuples, although you could argue it should be consistent with ParenExprs
 
   """a(b,
     |c => {
@@ -444,8 +442,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
   """Book(
     |  name = "Name",
     |  author = "Author",
-    |  rating = 5
-    |)"""
+    |  rating = 5)"""
 
   """foobar(
     |(1,2),
@@ -686,9 +683,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
      |  label("label"),
      |  popupMenu(
      |    viewer( // TODO
-     |    )
-     |  )
-     |)"""
+     |    )))"""
 
    """a(b)
      |.c(d)
@@ -743,8 +738,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
      |   i => List.range(1, i) map (j => (i, j))
      |)""" ==>
    """List.range(1, r) flatMap (
-     |  i => List.range(1, i) map (j => (i, j))
-     |)"""
+     |  i => List.range(1, i) map (j => (i, j)))"""
 
    """a map {
      |  b =>
@@ -799,12 +793,10 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
   """a(
     |  b,
     |  c,
-    |  d
-    |)(
+    |  d)(
     |  e,
     |  f,
-    |  g
-    |)"""
+    |  g)"""
 
   {
     implicit val formattingPreferences = FormattingPreferences.setPreference(AlignArguments, true)
@@ -856,14 +848,11 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
            |    zzz(
            |      a,
            |      b,
-           |      c
-           |    )
-           |  ),
+           |      c)),
            |  c(firstGroupOne(x)),
            |  d,
            |  e,
-           |  f
-           |)"""
+           |  f)"""
 
        """o.manyArguments(
          |  abc = 0,
@@ -879,8 +868,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
          |  abcTwo,
          |  abcThree = 3,
          |  abcFour  = 4,
-         |  abcFive  = 3
-         |)"""
+         |  abcFive  = 3)"""
 
        """Nested1(abcccc = 1,
          |  abc2     = 2,
@@ -889,8 +877,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
        """Nested1(
          |  abcccc   = 1,
          |  abc2     = 2,
-         |  abcThree = 3
-         |)"""
+         |  abcThree = 3)"""
 
        """o.grouped(
          |  firstGroupOne = 1,
@@ -910,8 +897,7 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
          |  secondGroup2   = "Two",
          |
          |  thirdGroupOne = 3,
-         |  thirdGroup2   = Three(3)
-         |)"""
+         |  thirdGroup2   = Three(3))"""
 
       """multiClause(
          |  arg1 = 1,
@@ -924,13 +910,10 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
          |)""" ==>
       """multiClause(
          |  arg1      = 1,
-         |  argument2 = 2
-         |)(
+         |  argument2 = 2)(
          |  args3 = 3,
-         |  arg4  = 4
-         |)(
-         |  arg5 = 5
-         |)"""
+         |  arg4  = 4)(
+         |  arg5 = 5)"""
 
    """a(
       |b = c
@@ -940,11 +923,9 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
       |)(
       |d)""" ==>
       """a(
-        |  b = c
-        |)(
+        |  b = c)(
         |  c,
-        |  d
-        |)(
+        |  d)(
         |  d)"""
 
    """Nested0(
@@ -961,14 +942,11 @@ class MiscExpressionFormatterTest extends AbstractExpressionFormatterTest {
        |  arg1 = Nested1(
        |    abcccc   = 1,
        |    abc2     = 2,
-       |    abcThree = 3
-       |  ),
+       |    abcThree = 3),
        |  NestedTwo(
        |    abcccc   = 1,
        |    abc2     = 2,
-       |    abcThree = 3
-       |  )
-       |)"""
+       |    abcThree = 3))"""
 }
   override val debug = false
 }

--- a/scalariform/src/test/scala/scalariform/formatter/MiscFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/MiscFormatterTest.scala
@@ -10,8 +10,7 @@ class MiscFormatterTest extends AbstractFormatterTest {
     |)""" ==>
   """class Foo(
     |  bar: String,
-    |  baz: String
-    |)"""
+    |  baz: String)"""
 
   """class Foo(
     |  bar: String,

--- a/scalariform/src/test/scala/scalariform/formatter/MiscFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/MiscFormatterTest.scala
@@ -18,8 +18,7 @@ class MiscFormatterTest extends AbstractFormatterTest {
     |  baz: String)""" ==>
   """class Foo(
     |  bar: String,
-    |  baz: String
-    |)"""
+    |  baz: String)"""
 
   """class Foo(
     |)""" ==>

--- a/scalariform/src/test/scala/scalariform/formatter/ParenAndBracketSpacingTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/ParenAndBracketSpacingTest.scala
@@ -27,7 +27,8 @@ class ParenAndBracketSpacingTest extends AbstractExpressionFormatterTest {
       |beta = bar match {
       |  case _ => "bar"
       |},
-      |gamma = false)""" ==>
+      |gamma = false
+      |)""" ==>
     """foo(
       |  alpha = "foo",
       |  beta = bar match {
@@ -41,7 +42,8 @@ class ParenAndBracketSpacingTest extends AbstractExpressionFormatterTest {
       |beta = bar(
       |a = 1
       |),
-      |gamma = false)""" ==>
+      |gamma = false
+      |)""" ==>
     """foo(
       |  alpha = "foo",
       |  beta = bar(

--- a/scalariform/src/test/scala/scalariform/formatter/ParenAndBracketSpacingTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/ParenAndBracketSpacingTest.scala
@@ -34,8 +34,7 @@ class ParenAndBracketSpacingTest extends AbstractExpressionFormatterTest {
       |  beta = bar match {
       |    case _ => "bar"
       |  },
-      |  gamma = false
-      |)"""
+      |  gamma = false)"""
 
     """foo(
       |alpha = "foo",
@@ -47,10 +46,8 @@ class ParenAndBracketSpacingTest extends AbstractExpressionFormatterTest {
     """foo(
       |  alpha = "foo",
       |  beta = bar(
-      |    a = 1
-      |  ),
-      |  gamma = false
-      |)"""
+      |    a = 1),
+      |  gamma = false)"""
 
     """foo(
       |arg = bar(
@@ -59,9 +56,7 @@ class ParenAndBracketSpacingTest extends AbstractExpressionFormatterTest {
       |)""" ==>
     """foo(
       |  arg = bar(
-      |    baz = "a"
-      |  ).xyz
-      |)"""
+      |    baz = "a").xyz)"""
   }
 
   {

--- a/scalariform/src/test/scala/scalariform/formatter/TemplateFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/TemplateFormatterTest.scala
@@ -99,8 +99,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |      case b =>
     |        val c = { d: Int => 1 }
     |        1.toString
-    |    }
-    |  )
+    |    })
     |}"""
 
   """class C1492 {
@@ -350,15 +349,13 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     """def A(
       |  a:   A ⇒ B = null,
       |  bee: ⇒ B   = null,
-      |  c:   B ⇒ C = null
-      |): D"""
+      |  c:   B ⇒ C = null): D"""
 
   """class a(
      |  b: Int
      |)""" ==>
    """class a(
-     |  b: Int
-     |)"""
+     |  b: Int)"""
 
    """class a(
      |  a: String = "",
@@ -424,8 +421,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
   """private def executeWithinClient[T](
     |  crawlerConfig: String => JsValue      = Fancy.function,
     |  f:             HttpCrawlerClient => T,
-    |  port:          Int                    = SpecHelper.port
-    |): T"""
+    |  port:          Int                    = SpecHelper.port): T"""
 
     // By name parameters have correct spacing
   """def a(
@@ -434,8 +430,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |): A""" ==>
   """def a(
     |  p1:     => (SomeLongByNameParam => SomeShorterParam) = Null,
-    |  param2: SomeShorterParam                             = Null
-    |): A"""
+    |  param2: SomeShorterParam                             = Null): A"""
 
     // Formats parameterized types correctly
     """def A(complicatedType: Option[B  ,C,      D[E, F,G]] = None,
@@ -443,8 +438,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
       |): B""" ==>
     """def A(
       |  complicatedType: Option[B, C, D[E, F, G]] = None,
-      |  simpleType:      String                   = ""
-      |): B"""
+      |  simpleType:      String                   = ""): B"""
 
     // Param gets placed onto a new line due to current limitations of existing IntertokenFormatInstructions
   """case class Spacing(param: Int = 1,
@@ -454,8 +448,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
   """case class Spacing(
     |  param:      Int    = 1,
     |  paramTwo:   Int    = 2,
-    |  paramThree: String = "3"
-    |)"""
+    |  paramThree: String = "3")"""
 
     // Groups and formats consecutive single line parameters (multi line params)
   """case class Spacing(param: Int = 1,
@@ -487,8 +480,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |  paramTwo: Int = 2,
     |
     |  paramFour: Option[String] = Some("One"),
-    |  paramFive: Any            = Nothing
-    |)"""
+    |  paramFive: Any            = Nothing)"""
 
     // Aligns implicits and curried parameters properly
   """class SomeClass(
@@ -504,10 +496,8 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
   """class SomeClass(
     |  parameterOne:     Int            = 1,
     |  val parameterTwo: Option[String] = None,
-    |  three:            String         = "three"
-    |)(
-    |  intermediate: Int
-    |)(
+    |  three:            String         = "three")(
+    |  intermediate: Int)(
     |  implicit
     |  val four: Int,
     |  five:     String,

--- a/scalariform/src/test/scala/scalariform/formatter/TemplateFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/TemplateFormatterTest.scala
@@ -296,8 +296,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |    def open(): Unit
     |    def close(): Unit
     |  },
-    |  o: Int
-    |)"""
+    |  o: Int)"""
 
   """class A(
     |n: Int, m: {def foo(): Int
@@ -314,8 +313,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |  m: {
     |    def foo(): Int
     |    def bar(a: String): Int
-    |  }
-    |)"""
+    |  })"""
 
 {
    implicit val formattingPreferences = FormattingPreferences.
@@ -328,16 +326,14 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |abc: Boolean = true): Int""" ==>
   """def a(
     |  a :   Int     = 1,
-    |  abc : Boolean = true
-    |) : Int"""
+    |  abc : Boolean = true) : Int"""
 
   """def a(
     |a: Option[Either[Int]] = 1,
     |abc: Boolean = true): Int""" ==>
   """def a(
     |  a :   Option[ Either[ Int ] ] = 1,
-    |  abc : Boolean                 = true
-    |) : Int"""
+    |  abc : Boolean                 = true) : Int"""
 }
 
 {
@@ -417,14 +413,14 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |  messageType: Message.Value = Message.Question,
     |  icon:        Icon          = EmptyIcon,
     |  entries:     Seq[A]        = Nil,
-    |  initial:     A
-    |): Option[A]"""
+    |  initial:     A): Option[A]"""
 
     // Formats function types correctly
   """private def executeWithinClient[T](
     |crawlerConfig: String => JsValue = Fancy.function,
     |f: HttpCrawlerClient => T,
-    |port: Int = SpecHelper.port): T""" ==>
+    |port: Int = SpecHelper.port
+    |): T""" ==>
   """private def executeWithinClient[T](
     |  crawlerConfig: String => JsValue      = Fancy.function,
     |  f:             HttpCrawlerClient => T,
@@ -434,7 +430,8 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     // By name parameters have correct spacing
   """def a(
     |  p1: => (SomeLongByNameParam => SomeShorterParam) = Null,
-    |  param2: SomeShorterParam = Null): A""" ==>
+    |  param2: SomeShorterParam = Null
+    |): A""" ==>
   """def a(
     |  p1:     => (SomeLongByNameParam => SomeShorterParam) = Null,
     |  param2: SomeShorterParam                             = Null
@@ -442,7 +439,8 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
 
     // Formats parameterized types correctly
     """def A(complicatedType: Option[B  ,C,      D[E, F,G]] = None,
-      | simpleType: String = ""): B""" ==>
+      | simpleType: String = ""
+      |): B""" ==>
     """def A(
       |  complicatedType: Option[B, C, D[E, F, G]] = None,
       |  simpleType:      String                   = ""
@@ -451,7 +449,8 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     // Param gets placed onto a new line due to current limitations of existing IntertokenFormatInstructions
   """case class Spacing(param: Int = 1,
     |paramTwo: Int = 2,
-    |paramThree: String = "3")""" ==>
+    |paramThree: String = "3"
+    |)""" ==>
   """case class Spacing(
     |  param:      Int    = 1,
     |  paramTwo:   Int    = 2,
@@ -473,8 +472,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |    val test: Int
     |  },
     |  paramFour: Option[String] = Some("One"),
-    |  paramFive: Any            = Nothing
-    |)"""
+    |  paramFive: Any            = Nothing)"""
 
     // Groups and formats consecutive single line parameters (newlines)
   """case class Spacing(
@@ -482,7 +480,8 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |paramTwo: Int = 2,
     |
     |paramFour: Option[String] = Some("One"),
-    |paramFive: Any = Nothing)""" ==>
+    |paramFive: Any = Nothing
+    |)""" ==>
   """case class Spacing(
     |  param:    Int = 1,
     |  paramTwo: Int = 2,
@@ -495,7 +494,8 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
   """class SomeClass(
     |parameterOne: Int = 1,
     |val parameterTwo: Option[String] = None,
-    |three: String = "three")(
+    |three: String = "three"
+    |)(
     |intermediate: Int
     |)(
     |implicit val four: Int,
@@ -511,8 +511,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |  implicit
     |  val four: Int,
     |  five:     String,
-    |  six:      Boolean
-    |)"""
+    |  six:      Boolean)"""
 
    // Handles annotations, modifiers, and comments
   """def extraStuff(
@@ -524,8 +523,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |  // comment 1
     |  @Annotated paramOne:                                                               Int         = 1, // comment 2
     |  /* comment 3 */ private val modifiedTwo:                                           String      = "two",
-    |  @Annotated2("complicatedAnnotation")@A3("Another") protected annotatedAndModified: Option[Int] = Some(3)
-    |)"""
+    |  @Annotated2("complicatedAnnotation")@A3("Another") protected annotatedAndModified: Option[Int] = Some(3))"""
 
   """class A(n: Int,
     |z: { val m
@@ -537,8 +535,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |    val m
     |    val n
     |  },
-    |  m: Int
-    |)"""
+    |  m: Int)"""
 
   """class A(m: Int,
     |n: {
@@ -556,8 +553,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |  },
     |  o: Int = {
     |    42
-    |  }
-    |)"""
+    |  })"""
 
   """class A(n: {
     | def close(): Unit
@@ -569,8 +565,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |    def close(): Unit
     |    def open(): Unit
     |  },
-    |  m: Int
-    |)"""
+    |  m: Int)"""
 
   """class A(
     |implicit n: {
@@ -582,8 +577,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |  n: {
     |    def x: Int
     |    def y: Int
-    |  }
-    |)"""
+    |  })"""
 
   """class A(n: {
     |def x: Int
@@ -597,10 +591,9 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |})""" ==>
   """class A(
     |  a: Int,
-    |  b: Int
-    |)(c: {
-    |    val d: Int
-    |  })"""
+    |  b: Int)(c: {
+    |            val d: Int
+    |          })"""
 
   }
 
@@ -609,8 +602,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
     |})""" ==>
   """class A(
     |  a: Int,
-    |  b: Int
-    |)(c: {
+    |  b: Int)(c: {
     |  val d: Int
     |})"""
 
@@ -625,8 +617,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
       |    with Serializable""" ==>
     """class Person(
       |  name: String,
-      |  age: Int
-      |)
+      |  age: Int)
       |    extends Entity
       |    with Logging
       |    with Identifiable
@@ -639,8 +630,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
       |}""" ==>
     """class Person(
       |    name: String,
-      |    age: Int
-      |) {
+      |    age: Int) {
       |  def firstMethod = 42
       |}"""
 
@@ -667,8 +657,7 @@ implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesW
       |}""" ==>
     """class Person(
       |  name: String,
-      |  age: Int
-      |)
+      |  age: Int)
       |    extends Entity {
       |  def method() = 42
       |}"""


### PR DESCRIPTION
Fixes #199 .

Milestone 1.0 per #142 .

Note that I also removed the deprecated (& undocumented) `preserveDanglingCloseParenthesis` from the README examples.