### PR TITLE
Ensure a gap after modifiers in a variable or method declaration / definition

### DIFF
--- a/scalariform/src/main/scala/scalariform/formatter/ExprFormatter.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/ExprFormatter.scala
@@ -957,6 +957,13 @@ trait ExprFormatter { self: HasFormattingPreferences with AnnotationFormatter wi
         formatResult = formatResult.before(firstPostAnnotationToken, instruction)
       }
     }
+    // Ensure spacing after any modifiers. If the last modifier is simply a newline, skip the gap,
+    // as this will already cause a space to be added.
+    // TODO: Update the `Modifier` parsing to handle newlines more gracefully, instead of putting
+    // them in a dummy `SimpleModifier`.
+    if (modifiers.nonEmpty && !modifiers.last.firstToken.tokenType.isNewline) {
+      formatResult = formatResult.before(defOrDcl.firstToken, CompactEnsuringGap)
+    }
     formatResult ++= format(defOrDcl)
     formatResult
   }

--- a/scalariform/src/test/scala/scalariform/formatter/TemplateFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/TemplateFormatterTest.scala
@@ -49,6 +49,9 @@ class TemplateFormatterTest extends AbstractFormatterTest {
 """@A@B(c = "d")abstract class E [F]@G()private(val h: I) (implicit j: K) extends{} with L(2) with M{}""" ==>
 """@A @B(c = "d") abstract class E[F] @G() private (val h: I)(implicit j: K) extends {} with L(2) with M {}"""
 
+"""class Foo {private[Foo]type Bar=String}""" ==>
+  """class Foo { private[Foo] type Bar = String }"""
+
 """@A/*a*/@B
    |/*b*/class E""" =/=>
 """@A/*a*/


### PR DESCRIPTION
Fixes #179.