### PR TITLE
Introduce `MultilineConstructorArgumentsDeclaration` as a new preference

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -433,7 +433,7 @@ doubleIndentClassDeclaration
 Default: ``false``
 
 With this set to ``true``, class (and trait / object) declarations
-will be formatted as recommended_ by the Scala Style Guide.
+will be formatted as recommended_ by the Scala Style Guide. That is,
 if the declaration section spans multiple lines, it will be formatted
 so that either the parameter section or the inheritance section is
 doubly indented. This provides a visual distinction from the members

--- a/README.rst
+++ b/README.rst
@@ -433,8 +433,11 @@ doubleIndentClassDeclaration
 Default: ``false``
 
 With this set to ``true``, class (and trait / object) declarations
-which span multiple lines, it will be formatted so that either the
-the inheritance section is doubly indented.
+will be formatted as recommended_ by the Scala Style Guide.
+if the declaration section spans multiple lines, it will be formatted
+so that either the parameter section or the inheritance section is
+doubly indented. This provides a visual distinction from the members
+of the class. For example:
 
 .. code:: scala
 
@@ -452,8 +455,10 @@ the inheritance section is doubly indented.
     def firstMethod = ...
   }
 
-multilineConstructorArgumentsDeclaration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This setting will be overridden by ``doubleIndentConstructorArguments``.
+
+doubleIndentConstructorArguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Default: ``false``
 

--- a/README.rst
+++ b/README.rst
@@ -433,11 +433,8 @@ doubleIndentClassDeclaration
 Default: ``false``
 
 With this set to ``true``, class (and trait / object) declarations
-will be formatted as recommended_ by the Scala Style Guide. That is,
-if the declaration section spans multiple lines, it will be formatted
-so that either the parameter section or the inheritance section is
-doubly indented. This provides a visual distinction from the members
-of the class. For example:
+which span multiple lines, it will be formatted so that either the
+the inheritance section is doubly indented.
 
 .. code:: scala
 
@@ -453,6 +450,32 @@ of the class. For example:
       with Identifiable
       with Serializable {
     def firstMethod = ...
+  }
+
+multilineConstructorArgumentsDeclaration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``false``
+
+With this set to ``true``, class (and trait / object) declarations
+will be formatted as recommended_ by the Scala Style Guide. That is,
+if the declaration section spans multiple lines, it will be formatted
+so that the parameter section is doubly indented. This provides a visual
+distinction between the constructor arguments & the extensions. For example:
+
+.. code:: scala
+
+  class Person(
+      name: String,
+      age: Int,
+      birthdate: Date,
+      astrologicalSign: String,
+      shoeSize: Int,
+      favoriteColor: java.awt.Color)
+    extends Entity
+    with Logging
+    with Identifiable
+    with Serializable {
   }
 
 Or:

--- a/scalariform/src/main/scala/scalariform/formatter/TemplateFormatter.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/TemplateFormatter.scala
@@ -34,11 +34,11 @@ trait TemplateFormatter { self: HasFormattingPreferences with AnnotationFormatte
         !templateInheritanceSectionOpt.exists { section ⇒
           containsNewline(section) || hiddenPredecessors(section.firstToken).containsNewline
         } &&
-        templateBodyOption.exists(containsNewline(_))) || formattingPreferences(MultilineConstructorArgumentsDeclaration)
+        templateBodyOption.exists(containsNewline(_))) || formattingPreferences(DoubleIndentConstructorArguments)
       formatResult ++= formatParamClauses(paramClauses, doubleIndentParams)
     }
     for (TemplateInheritanceSection(extendsOrSubtype, earlyDefsOpt, templateParentsOpt) ← templateInheritanceSectionOpt) {
-      val doubleIndentTemplateInheritance = !formattingPreferences(MultilineConstructorArgumentsDeclaration) &&
+      val doubleIndentTemplateInheritance = !formattingPreferences(DoubleIndentConstructorArguments) &&
         formattingPreferences(DoubleIndentClassDeclaration) &&
         (templateBodyOption.exists(containsNewline(_)) || paramClausesOpt.exists(containsNewline(_)))
       val inheritanceIndent = if (doubleIndentTemplateInheritance) 2 else 1

--- a/scalariform/src/main/scala/scalariform/formatter/TemplateFormatter.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/TemplateFormatter.scala
@@ -30,13 +30,16 @@ trait TemplateFormatter { self: HasFormattingPreferences with AnnotationFormatte
     } {
       if (annotations.size > 0)
         formatResult = formatResult.formatNewlineOrOrdinary(firstToken, CompactEnsuringGap)
-      val doubleIndentParams = formattingPreferences(DoubleIndentClassDeclaration) &&
-        !templateInheritanceSectionOpt.exists { section ⇒ containsNewline(section) || hiddenPredecessors(section.firstToken).containsNewline } &&
-        templateBodyOption.exists(containsNewline(_))
+      val doubleIndentParams = (formattingPreferences(DoubleIndentClassDeclaration) &&
+        !templateInheritanceSectionOpt.exists { section ⇒
+          containsNewline(section) || hiddenPredecessors(section.firstToken).containsNewline
+        } &&
+        templateBodyOption.exists(containsNewline(_))) || formattingPreferences(MultilineConstructorArgumentsDeclaration)
       formatResult ++= formatParamClauses(paramClauses, doubleIndentParams)
     }
     for (TemplateInheritanceSection(extendsOrSubtype, earlyDefsOpt, templateParentsOpt) ← templateInheritanceSectionOpt) {
-      val doubleIndentTemplateInheritance = formattingPreferences(DoubleIndentClassDeclaration) &&
+      val doubleIndentTemplateInheritance = !formattingPreferences(MultilineConstructorArgumentsDeclaration) &&
+        formattingPreferences(DoubleIndentClassDeclaration) &&
         (templateBodyOption.exists(containsNewline(_)) || paramClausesOpt.exists(containsNewline(_)))
       val inheritanceIndent = if (doubleIndentTemplateInheritance) 2 else 1
       var currentFormatterState = formatterState

--- a/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
@@ -166,7 +166,7 @@ case object FirstArgumentOnNewline extends IntentPreferenceDescriptor {
   val defaultValue = Force
 }
 
-@deprecated("This has been dropped in favor of MultilineConstrucmtorArgumentsDeclaration.", since = "0.1.5")
+@deprecated("This has been dropped in favor of DoubleIndentConstructorArguments.", since = "0.1.5")
 case object DoubleIndentClassDeclaration extends BooleanPreferenceDescriptor {
   val key = "doubleIndentClassDeclaration"
   val description = "Double indent either a class's parameters or its inheritance list"

--- a/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
@@ -166,9 +166,16 @@ case object FirstArgumentOnNewline extends IntentPreferenceDescriptor {
   val defaultValue = Force
 }
 
+@deprecated("This has been dropped in favor of MultilineConstrucmtorArgumentsDeclaration.", since = "0.1.5")
 case object DoubleIndentClassDeclaration extends BooleanPreferenceDescriptor {
   val key = "doubleIndentClassDeclaration"
   val description = "Double indent either a class's parameters or its inheritance list"
+  val defaultValue = false
+}
+
+case object MultilineConstructorArgumentsDeclaration extends BooleanPreferenceDescriptor {
+  val key = "MultilineConstructorArgumentsDeclaration"
+  val description = "Class (and trait / object) declarations will be formatted as recommended by the Scala Style Guide"
   val defaultValue = false
 }
 

--- a/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
@@ -173,8 +173,8 @@ case object DoubleIndentClassDeclaration extends BooleanPreferenceDescriptor {
   val defaultValue = false
 }
 
-case object MultilineConstructorArgumentsDeclaration extends BooleanPreferenceDescriptor {
-  val key = "MultilineConstructorArgumentsDeclaration"
+case object DoubleIndentConstructorArguments extends BooleanPreferenceDescriptor {
+  val key = "doubleIndentConstructorArguments"
   val description = "Class (and trait / object) declarations will be formatted as recommended by the Scala Style Guide"
   val defaultValue = false
 }

--- a/scalariform/src/test/scala/scalariform/formatter/DoubleIndentConstructorArgumentsTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/DoubleIndentConstructorArgumentsTest.scala
@@ -3,7 +3,7 @@ package scalariform.formatter
 import scalariform.formatter.preferences._
 import scalariform.parser._
 
-class MultilineConstructorArgumentsDeclarationTest extends AbstractFormatterTest {
+class DoubleIndentConstructorArgumentsTest extends AbstractFormatterTest {
   override val debug = false
 
   def parse(parser: ScalaParser) = parser.nonLocalDefOrDcl()
@@ -12,7 +12,7 @@ class MultilineConstructorArgumentsDeclarationTest extends AbstractFormatterTest
 
   def format(formatter: ScalaFormatter, result: Result) = formatter.format(result)(FormatterState(indentLevel = 0))
 
-  implicit val formattingPreferences = FormattingPreferences.setPreference(MultilineConstructorArgumentsDeclaration, true)
+  implicit val formattingPreferences = FormattingPreferences.setPreference(DoubleIndentConstructorArguments, true)
   """class Person(
     |  name: String,
     |  age: Int)

--- a/scalariform/src/test/scala/scalariform/formatter/MultilineConstructorArgumentsDeclarationTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/MultilineConstructorArgumentsDeclarationTest.scala
@@ -1,0 +1,90 @@
+package scalariform.formatter
+
+import scalariform.formatter.preferences._
+import scalariform.parser._
+
+class MultilineConstructorArgumentsDeclarationTest extends AbstractFormatterTest {
+  override val debug = false
+
+  def parse(parser: ScalaParser) = parser.nonLocalDefOrDcl()
+
+  type Result = FullDefOrDcl
+
+  def format(formatter: ScalaFormatter, result: Result) = formatter.format(result)(FormatterState(indentLevel = 0))
+
+  implicit val formattingPreferences = FormattingPreferences.setPreference(MultilineConstructorArgumentsDeclaration, true)
+  """class Person(
+    |  name: String,
+    |  age: Int)
+    |    extends Entity
+    |    with Logging
+    |    with Identifiable
+    |    with Serializable""" ==>
+    """class Person(
+      |    name: String,
+      |    age: Int)
+      |  extends Entity
+      |  with Logging
+      |  with Identifiable
+      |  with Serializable"""
+
+  """class Person(
+    |    name: String,
+    |    age: Int) {
+    |  def firstMethod = 42
+    |}""" ==>
+    """class Person(
+      |    name: String,
+      |    age: Int) {
+      |  def firstMethod = 42
+      |}"""
+
+  """class Person(name: String, age: Int, birthdate: Date, astrologicalSign: String, shoeSize: Int, favoriteColor: java.awt.Color)
+    |extends Entity
+    |with Logging
+    |with Identifiable
+    |with Serializable {
+    |def firstMethod = 42
+    |}""" ==>
+    """class Person(name: String, age: Int, birthdate: Date, astrologicalSign: String, shoeSize: Int, favoriteColor: java.awt.Color)
+      |  extends Entity
+      |  with Logging
+      |  with Identifiable
+      |  with Serializable {
+      |  def firstMethod = 42
+      |}"""
+
+  """class Person(
+    |name: String,
+    |  age: Int
+    |  )
+    |extends Entity  {
+    |def method() = 42
+    |}""" ==>
+    """class Person(
+      |    name: String,
+      |    age: Int)
+      |  extends Entity {
+      |  def method() = 42
+      |}"""
+
+  """trait A
+    |extends B
+    |with C {
+    |println("d")
+    |}""" ==>
+    """trait A
+      |  extends B
+      |  with C {
+      |  println("d")
+      |}"""
+
+  """class Person(
+    |  name: String,
+    |  age: Int)
+    |    extends Entity with Logging""" ==>
+    """class Person(
+      |    name: String,
+      |    age: Int)
+      |  extends Entity with Logging"""
+}


### PR DESCRIPTION
reviving https://github.com/scala-ide/scalariform/pull/192

> The current version of the Scala style guide prescribes indenting multi-line constructor arguments 4 spaces, with extensions indented 2: http://docs.scala-lang.org/style/declarations.html#classes

changes:
- introduced a new preference as requested by @sschaef in @kelseyq 's PR
- deprecate doubleIndentClassDeclaration
- tests for the new preference 
