### PR TITLE
Fix bundle version string in manifest file

### DIFF
--- a/scalariform/META-INF/MANIFEST.MF
+++ b/scalariform/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scalariform
 Bundle-SymbolicName: scalariform
-Bundle-Version: 0.2.5
+Bundle-Version: 0.2.5.qualifier
 Require-Bundle: org.scala-lang.scala-library,
  org.scala-lang.modules.scala-xml
 Bundle-ClassPath: .


### PR DESCRIPTION
The `.qualifier` appendix is required, otherwise the bundle version is
not correctly set.

-------

If you do not need the OSGi configuration, we can get rid of it because scala-ide no longer needs it.