### PR TITLE
Fix StackOverflowError in Utils.groupBy

### DIFF
--- a/scalariform/src/main/scala/scalariform/utils/Utils.scala
+++ b/scalariform/src/main/scala/scalariform/utils/Utils.scala
@@ -3,6 +3,7 @@ package scalariform.utils
 import java.io.FileOutputStream
 import java.io.FileInputStream
 import java.io.IOException
+import scala.collection.mutable.ListBuffer
 
 object Utils {
 
@@ -31,14 +32,20 @@ object Utils {
     }
   }
 
-  def groupBy[A](eq: (A, A) ⇒ Boolean, lst: List[A]): List[List[A]] =
-    lst match {
-      case Nil ⇒ Nil
-      case (x :: xs) ⇒ {
-        val (ys, zs) = xs span { eq(x, _) }
-        (x :: ys) :: groupBy(eq, zs)
+  def groupBy[A](eq: (A, A) ⇒ Boolean, lst: List[A]): List[List[A]] = {
+    val result = ListBuffer[List[A]]()
+    @annotation.tailrec def loop(cursor: List[A]): Unit =
+      cursor match {
+        case Nil ⇒
+        case (x :: xs) ⇒ {
+          val (ys, zs) = xs span { eq(x, _) }
+          result += x :: ys
+          loop(zs)
+        }
       }
-    }
+    loop(lst)
+    result.toList
+  }
 
   // File ------------------
 

--- a/scalariform/src/test/scala/scalariform/parser/ParserTest.scala
+++ b/scalariform/src/test/scala/scalariform/parser/ParserTest.scala
@@ -48,6 +48,11 @@ class ParserTest extends FlatSpec with Matchers {
     """)
   }
 
+  // issue #265
+  "Parser" should "handle deep complex expressions" in {
+    parseExpression("o.p(a" + (",a" * 3000) + ")")
+  }
+
   private def parser(s: String) = new ScalaParser(ScalaLexer.tokenise(s).toArray)
   private def parseExpression(s: String) = parser(s).expr
   private def parseCompilationUnit(s: String) = parser(s).compilationUnit


### PR DESCRIPTION
Fixes #265. I didn't add extra tests for groupBy because it seemed well covered by the other tests in the repo.