### PR TITLE
Fix type mismatch between `Unit` and `TokenType`

### DIFF
--- a/scalariform/src/test/scala/scalariform/lexer/ScalaLexerTest.scala
+++ b/scalariform/src/test/scala/scalariform/lexer/ScalaLexerTest.scala
@@ -10,7 +10,7 @@ class ScalaLexerTest extends FlatSpec with Matchers {
                                             scalaVersion: ScalaVersion = ScalaVersions.DEFAULT): TestString =
     new TestString(s, forgiveErrors, scalaVersion)
 
-  "" producesTokens ()
+  "" producesTokens (List.empty[TokenType]: _*)
 
   "println" producesTokens (VARID)
 


### PR DESCRIPTION
This was uncovered in the community build for scala 2.13.0-RC1, see https://github.com/scala/bug/issues/11453