### PR TITLE
Introduce new setting `UseUnicodeArrows` to allow reversing arrow replacement

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+0.2.9 (unreleased)
+* Add new setting `UseUnicodeArrows` that allows to reverse the unicode arrow symbol replacement when set to false (in Scala 2.13 unicode arrows are deprecated)
+
 0.2.8 (29/March/19)
 
 * Fix type mismatch between `Unit` and `TokenType` (PR #276 by @Philippus)

--- a/README.rst
+++ b/README.rst
@@ -139,7 +139,7 @@ Use with Vim
 While there is no specific Vim integration at present, you can use
 Scalariform as an external formatter for the ``gg=G`` command by adding
 the following to ``.vimrc`` ::
-  
+
   au BufEnter *.scala setl formatprg=java\ -jar\ /home/me/bin/scalariform.jar\ -f\ -q\ +compactControlReadability\ +alignParameters\ +alignSingleLineCaseStatements\ +doubleIndentConstructorArguments\ +rewriteArrowSymbols\ +preserveSpaceBeforeArguments\ --stdin\ --stdout
   au BufEnter *.scala setl equalprg=java\ -jar\ /home/me/bin/scalariform.jar\ -f\ -q\ +compactControlReadability\ +alignParameters\ +alignSingleLineCaseStatements\ +doubleIndentConstructorArguments\ +rewriteArrowSymbols\ +preserveSpaceBeforeArguments\ --stdin\ --stdout
 
@@ -727,7 +727,10 @@ rewriteArrowSymbols
 
 Default: ``false``
 
-Replace arrow tokens with their unicode equivalents: ``=>`` with ``⇒``, and ``<-`` with ``←``. For example:
+Replace arrow tokens uniformly, either as Unicode symbols or as ASCII, depending on the setting of
+``useUnicodeArrows``. Starting from Scala 2.13, unicode arrows are deprecated.
+
+For example, if ``useUnicodeArrows == true``:
 
 .. code:: scala
 
@@ -866,6 +869,30 @@ If ``false``,:
 
   case elem@Multi(values@_*) =>
 
+useUnicodeArrows
+~~~~~~~~~~~~~~~~
+
+Default: ``true``
+
+Controls the replacement of arrows if ``rewriteArrowSymbols == true``. To use unicode arrows in your codebase
+set to `true`, otherwise, set to false. For example, if ``useUnicodeArrows == false`` (and ``rewriteArrowSymbols == true``):
+
+.. code:: scala
+
+  for (n ← 1 to 10) n % 2 match {
+    case 0 ⇒ println("even")
+    case 1 ⇒ println("odd")
+  }
+
+is formatted as:
+
+.. code:: scala
+
+  for (n <- 1 to 10) n % 2 match {
+    case 0 => println("even")
+    case 1 => println("odd")
+  }
+
 Scala Style Guide
 ~~~~~~~~~~~~~~~~~
 
@@ -889,6 +916,7 @@ spaceBeforeColon                            ``false``
 spaceInsideBrackets                         ``false``
 spaceInsideParentheses                      ``false``
 spacesAroundMultiImports                    ``false``
+useUnicodeArrows                            ``true``
 =========================================== ========= =========
 
 Source Directives

--- a/formatterPreferences.properties
+++ b/formatterPreferences.properties
@@ -28,3 +28,4 @@ danglingCloseParenthesis=Force
 #spaceInsideParentheses=false
 #spacesAroundMultiImports=true
 #spacesWithinPatternBinders=true
+#useUnicodeArrows=true

--- a/scalariform/src/main/scala/scalariform/formatter/CaseClauseFormatter.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/CaseClauseFormatter.scala
@@ -83,7 +83,12 @@ trait CaseClauseFormatter { self: HasFormattingPreferences with ExprFormatter wi
           if (formattedCasePattern.contains('\n') || (first && !clausesAreMultiline) || (!first && !newlineBeforeClause) || clauseBodyIsMultiline)
             Right(caseClause) :: otherClausesGrouped
           else {
-            val arrowAdjust = (if (formattingPreferences(RewriteArrowSymbols)) 1 else casePattern.arrow.length) + 1
+            val arrowAdjust = 1 + {
+              if (formattingPreferences(RewriteArrowSymbols))
+                if (formattingPreferences(UseUnicodeArrows)) 1
+                else 2
+              else casePattern.arrow.length
+            }
             val casePatternLength = formattedCasePattern.length - arrowAdjust
             otherClausesGrouped match {
               case Left(consecutiveSingleLineCaseClauses) :: otherGroups ⇒

--- a/scalariform/src/main/scala/scalariform/formatter/ScalaFormatter.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/ScalaFormatter.scala
@@ -285,9 +285,10 @@ abstract class ScalaFormatter
 
     def write(token: Token, replacementOption: Option[String] = None): Option[TextEdit] = {
       val rewriteArrows = formattingPreferences(RewriteArrowSymbols)
+      val useUnicodeArrows = formattingPreferences(UseUnicodeArrows)
       val actualReplacementOption = replacementOption orElse condOpt(token.tokenType) {
-        case ARROW if rewriteArrows  ⇒ "⇒"
-        case LARROW if rewriteArrows ⇒ "←"
+        case ARROW if rewriteArrows  ⇒ if (useUnicodeArrows) "⇒" else "=>"
+        case LARROW if rewriteArrows ⇒ if (useUnicodeArrows) "←" else "<-"
         case EOF                     ⇒ ""
       }
       builder.append(actualReplacementOption getOrElse token.rawText)

--- a/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/preferences/PreferenceDescriptor.scala
@@ -287,3 +287,9 @@ case object SpacesWithinPatternBinders extends BooleanPreferenceDescriptor {
   val description = "Spaces around the @ token in pattern binders"
   val defaultValue = true
 }
+
+case object UseUnicodeArrows extends BooleanPreferenceDescriptor {
+  val key = "useUnicodeArrows"
+  val description = "Use unicode arrows if RewriteArrowSymbols is used. If true, replace => with ⇒, and <- with ←, if false the other way round."
+  val defaultValue = true
+}

--- a/scalariform/src/test/scala/scalariform/formatter/CaseClausesFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/CaseClausesFormatterTest.scala
@@ -288,7 +288,10 @@ class CaseClausesFormatterTest extends AbstractExpressionFormatterTest {
 
   {
   implicit val formattingPreferences: FormattingPreferences =
-    FormattingPreferences.setPreference(AlignSingleLineCaseStatements, true).setPreference(RewriteArrowSymbols, true)
+    FormattingPreferences
+      .setPreference(AlignSingleLineCaseStatements, true)
+      .setPreference(RewriteArrowSymbols, true)
+      .setPreference(UseUnicodeArrows, true)
 
   """a match {
     |case b => 42
@@ -298,6 +301,24 @@ class CaseClausesFormatterTest extends AbstractExpressionFormatterTest {
     |  case b   ⇒ 42
     |  case ccc ⇒ 24
     |}"""
+  }
+
+  {
+    implicit val formattingPreferences: FormattingPreferences =
+      FormattingPreferences
+        .setPreference(AlignSingleLineCaseStatements, true)
+        .setPreference(RewriteArrowSymbols, true)
+        .setPreference(UseUnicodeArrows, false)
+
+
+    """a match {
+      |case b ⇒ 42
+      |  case ccc ⇒ 24
+      |}""" ==>
+    """a match {
+      |  case b   => 42
+      |  case ccc => 24
+      |}"""
   }
 
   {

--- a/scalariform/src/test/scala/scalariform/formatter/RewriteArrowsTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/RewriteArrowsTest.scala
@@ -5,15 +5,31 @@ import scalariform.formatter.preferences._
 // format: OFF
 class RewriteArrowsTest extends AbstractExpressionFormatterTest {
 
+  // test replacing into unicode
   {
     implicit val formattingPreferences: FormattingPreferences =
       FormattingPreferences.setPreference(RewriteArrowSymbols, true)
+      .setPreference(UseUnicodeArrows, true)
 
     "(a: Int) => 3" ==> "(a: Int) ⇒ 3"
     "for (i <- 1 to 10) yield i" ==> "for (i ← 1 to 10) yield i"
     // We don't rewrite RARROW anymore since it can be, and is, used as a
     // normal identifier.
     "cache += k -> f(k)" ==> "cache += k -> f(k)"
+  }
+
+  // test replacing from unicode
+  {
+    implicit val formattingPreferences: FormattingPreferences =
+      FormattingPreferences.setPreference(RewriteArrowSymbols, true)
+        .setPreference(UseUnicodeArrows, false)
+
+    "(a: Int) ⇒ 3" ==> "(a: Int) => 3"
+    "for (i ← 1 to 10) yield i" ==> "for (i <- 1 to 10) yield i"
+    // We don't rewrite RARROW anymore since it can be, and is, used as a
+    // normal identifier.
+    "cache += k -> f(k)" ==> "cache += k -> f(k)"
+    "cache += k → f(k)" ==> "cache += k → f(k)"
   }
 
   override val debug = false


### PR DESCRIPTION
This is needed because starting with Scala 2.13, unicode arrows are deprecated.