### PR TITLE
Support scala3 styled imports

### DIFF
--- a/scalariform/src/main/scala/scalariform/formatter/ScalaFormatter.scala
+++ b/scalariform/src/main/scala/scalariform/formatter/ScalaFormatter.scala
@@ -565,7 +565,7 @@ object ScalaFormatter {
     THROW, TRAIT, TRY, /* TYPE ,*/
     VAL, VAR, WHILE, WITH, YIELD,
     /* USCORE, */ COLON, EQUALS, ARROW, LARROW, SUBTYPE, VIEWBOUND, SUPERTYPE, /* HASH, AT */
-    LBRACE, SEMI)
+    LBRACE, SEMI, AS)
 
   val ENSURE_SPACE_BEFORE: Set[TokenType] = Set(
     ABSTRACT, CASE, CATCH, CLASS, DEF,
@@ -577,7 +577,7 @@ object ScalaFormatter {
     /* THROW, */ TRAIT, /* TRY, TYPE, */
     VAL, VAR, /* WHILE, */ WITH, YIELD,
     /* USCORE, COLON, */ EQUALS, /* ARROW, */ LARROW, SUBTYPE, VIEWBOUND, SUPERTYPE, /*, HASH, AT, */
-    RBRACE)
+    RBRACE, AS)
   // format: ON
 
   @throws(classOf[ScalaParserException])

--- a/scalariform/src/main/scala/scalariform/lexer/Keywords.scala
+++ b/scalariform/src/main/scala/scalariform/lexer/Keywords.scala
@@ -62,7 +62,8 @@ object Keywords {
     "*" -> STAR,
     "|" -> PIPE,
     "~" -> TILDE,
-    "!" -> EXCLAMATION
+    "!" -> EXCLAMATION,
+    "as" -> AS
   )
 
 }

--- a/scalariform/src/main/scala/scalariform/lexer/Tokens.scala
+++ b/scalariform/src/main/scala/scalariform/lexer/Tokens.scala
@@ -97,6 +97,7 @@ object Tokens {
   val XML_CDATA = TokenType("XML_CDATA", isXml = true)
   val XML_UNPARSED = TokenType("XML_UNPARSED", isXml = true)
   val XML_PROCESSING_INSTRUCTION = TokenType("XML_PROCESSING_INSTRUCTION", isXml = true)
+  val AS = TokenType("AS")
 
   val KEYWORDS: Set[TokenType] = Set(
     ABSTRACT, CASE, CATCH, CLASS, DEF,
@@ -106,7 +107,7 @@ object Tokens {
     OBJECT, OVERRIDE, PACKAGE, PRIVATE, PROTECTED,
     RETURN, SEALED, SUPER, THIS,
     THROW, TRAIT, TRY, TYPE,
-    VAL, VAR, WHILE, WITH, YIELD
+    VAL, VAR, WHILE, WITH, YIELD, AS
   )
 
   val COMMENTS: Set[TokenType] = Set(LINE_COMMENT, MULTILINE_COMMENT, XML_COMMENT)

--- a/scalariform/src/main/scala/scalariform/parser/ScalaParser.scala
+++ b/scalariform/src/main/scala/scalariform/parser/ScalaParser.scala
@@ -1322,10 +1322,10 @@ class ScalaParser(tokens: Array[Token]) {
   private def importSelector(): Expr = {
     val first = wildcardOrIdent()
     currentTokenType match {
-      case ARROW ⇒
-        val arrowToken = nextToken()
+      case ARROW | AS ⇒
+        val token = nextToken()
         val rename = wildcardOrIdent()
-        makeExpr(first, arrowToken, rename)
+        makeExpr(first, token, rename)
       case _ ⇒
         makeExpr(first)
     }

--- a/scalariform/src/test/scala/scalariform/formatter/ImportFormatterTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/ImportFormatterTest.scala
@@ -13,7 +13,9 @@ class ImportFormatterTest extends AbstractFormatterTest {
     "import foo . _" ==> "import foo._"
     "import foo . bar" ==> "import foo.bar"
     "import foo.{bar=>baz}" ==> "import foo.{ bar => baz }"
+    "import foo.{bar as baz}" ==> "import foo.{ bar as baz }"
     "import foo.{bar=>baz},baz.biz" ==> "import foo.{ bar => baz }, baz.biz"
+    "import foo.{bar as baz},baz.biz" ==> "import foo.{ bar as baz }, baz.biz"
     """import foo.{bar => baz,
         |wibble => wobble}""" ==>
       """import foo.{
@@ -29,7 +31,9 @@ class ImportFormatterTest extends AbstractFormatterTest {
     "import foo . _" ==> "import foo._"
     "import foo . bar" ==> "import foo.bar"
     "import foo.{bar=>baz}" ==> "import foo.{bar => baz}"
+    "import foo.{bar as baz}" ==> "import foo.{bar as baz}"
     "import foo.{bar=>baz},baz.biz" ==> "import foo.{bar => baz}, baz.biz"
+    "import foo.{bar as baz},baz.biz" ==> "import foo.{bar as baz}, baz.biz"
     """import foo.{bar => baz,
       |wibble => wobble}""" ==>
       """import foo.{


### PR DESCRIPTION
This PR allows following syntax
`import foo.{bar as baz}`