### PR TITLE
Support trailing commas in parameter declarations. Include newline after trailing comma.

### DIFF
--- a/scalariform/src/main/scala/scalariform/parser/AstNodes.scala
+++ b/scalariform/src/main/scala/scalariform/parser/AstNodes.scala
@@ -1,6 +1,6 @@
 package scalariform.parser
 
-import scalariform.lexer.Token
+import scalariform.lexer.{ Token, Tokens }
 import scalariform.utils.Range
 
 sealed trait AstNode extends Product {
@@ -154,6 +154,8 @@ case class BlockArgumentExprs(contents: List[ExprElement]) extends ArgumentExprs
 
 case class ParenArgumentExprs(lparen: Token, contents: List[ExprElement], rparen: Token) extends ArgumentExprs {
   lazy val tokens: List[Token] = flatten(lparen, contents, rparen)
+
+  lazy val hasTrailingComma: Boolean = flatten(contents).lastOption.exists(_.tokenType == Tokens.COMMA)
 }
 
 case class Argument(expr: Expr) extends AstNode with ExprElement {
@@ -303,7 +305,7 @@ case class ParamClauses(newlineOpt: Option[Token], paramClausesAndNewlines: List
 }
 
 case class ParamClause(lparen: Token, implicitOption: Option[Token], firstParamOption: Option[Param], otherParams: List[(Token, Param)], rparen: Token, trailComa: Option[Token]) extends AstNode {
-  lazy val tokens: List[Token] = flatten(lparen, implicitOption, firstParamOption, otherParams, rparen)
+  lazy val tokens: List[Token] = flatten(lparen, implicitOption, firstParamOption, otherParams, trailComa, rparen)
 }
 
 case class Param(annotations: List[Annotation], modifiers: List[Modifier], valOrVarOpt: Option[Token], id: Token, paramTypeOpt: Option[(Token, Type)], defaultValueOpt: Option[(Token, Expr)]) extends AstNode {
@@ -378,7 +380,7 @@ case class TemplateParents(typeAndArgs: (Type, List[ArgumentExprs]), withTypesAn
 }
 
 case class ImportClause(importToken: Token, importExpr: ImportExpr, otherImportExprs: List[(Token, ImportExpr)], trailOpt: Option[Token]) extends AstNode with Stat {
-  lazy val tokens: List[Token] = flatten(importToken, importExpr, otherImportExprs)
+  lazy val tokens: List[Token] = flatten(importToken, importExpr, otherImportExprs, trailOpt)
 }
 
 sealed trait ImportExpr extends AstNode

--- a/scalariform/src/test/scala/scalariform/formatter/TrailingCommasTest.scala
+++ b/scalariform/src/test/scala/scalariform/formatter/TrailingCommasTest.scala
@@ -1,15 +1,123 @@
 package scalariform.formatter
+
 import scalariform.parser._
 
 // format: OFF
 class TrailingCommasTest extends AbstractFormatterTest {
+  // Trailing comma must always be followed by a newline.
+  // Scalariform will insert a newline if it is missing, to make
+  // such code valid Scala.
 
-  """val foos = List(
-    |  f1,
-    |  f2,)""" ==>
-    """val foos = List(
-      |  f1,
-      |  f2, )"""
+  // The test cases with List() cover trailing commas in function invocations.
+
+  "val x = List()" ==> "val x = List()"
+  "val x = List(1)" ==> "val x = List(1)"
+  "val x = List(1, 2)" ==> "val x = List(1, 2)"
+
+  "val x = List(1,)" ==>
+    """val x = List(1,
+      |)"""
+
+  """val x = List(
+    |  1
+    |)""" ==>
+    """val x = List(
+      |  1)"""
+
+  """val x = List(
+    |  1,
+    |)""" ==>
+    """val x = List(
+      |  1,
+      |)"""
+
+  "val x = List(1, 2,)" ==>
+    """val x = List(1, 2,
+      |)"""
+
+  """val x = List(
+    |  1, 2
+    |)""" ==>
+    """val x = List(
+      |  1, 2)"""
+
+  """val x = List(
+    |  1, 2,
+    |)""" ==>
+    """val x = List(
+      |  1, 2,
+      |)"""
+
+  """val x = List(
+    |  1,
+    |  2,
+    |)""" ==>
+    """val x = List(
+      |  1,
+      |  2,
+      |)"""
+
+  """val x = List(
+    |  1,
+    |  2
+    |)""" ==>
+    """val x = List(
+      |  1,
+      |  2)"""
+
+  """val x = List(
+    |  1,
+    |  2,)""" ==>
+    """val x = List(
+      |  1,
+      |  2,
+      |)"""
+
+  // The test cases with case class cover trailing commas in parameter declarations.
+
+  "case class A" ==> "case class A"
+  "case class A()" ==> "case class A()"
+  "case class A(x: Int)" ==> "case class A(x: Int)"
+  "case class A(x: Int,)" ==>
+    """case class A(
+      |  x: Int,
+      |)"""
+
+  "case class A(x: Int, y: Int)" ==> "case class A(x: Int, y: Int)"
+  "case class A(x: Int, y: Int,)" ==>
+    """case class A(
+      |  x: Int, y: Int,
+      |)"""
+
+  """case class A(
+    |  x: Int,
+    |  y: Int,
+    |)""" ==>
+    """case class A(
+      |  x: Int,
+      |  y: Int,
+      |)"""
+
+  """case class A(
+    |  x: Int,
+    |  y: Int,)""" ==>
+    """case class A(
+      |  x: Int,
+      |  y: Int,
+      |)"""
+
+  """case class A(
+    |  x: Int, y: Int,
+    |)""" ==>
+    """case class A(
+      |  x: Int, y: Int,
+      |)"""
+
+  """case class A(
+    |  x: Int, y: Int,)""" ==>
+    """case class A(
+      |  x: Int, y: Int,
+      |)"""
 
   //  format: ON
 


### PR DESCRIPTION
Hi, the initial trailing comma support (#262) is very limited. Even the "expected" code in the test case is not valid (it expects the trailing comma in the same line as closing paren which is forbidden in Scala). The other problem with current master is that whenever the trailing comma appears in parameter declaration (eg. case class fields or function declaration), an assertion fails with `java.lang.IllegalArgumentException: requirement failed: Parse tokens differ from expected.` (`SpecificFormatter.scala:54`).

My commit fixes both of these issues.

1. The assert is fixed by adding the trailing comma token back to the `tokens` field in classes `ImportClause` and `ParamClause` in AstNodes.scala. This also prevents the trailing comma from disappearing in the formatted code.
2. I enforce a newline after a trailing comma even if the preference `DanglingCloseParenthesis` would not normally result in a newline. This is to prevent Scala compiler errors.

I added a bunch of test cases.

Please let me know if you can merge this and make a new release, so that this fix could be propagated to sbt-scalariform.